### PR TITLE
changed frontmatter to head for brevity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ name = "bartholomew"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "handlebars",
  "pulldown-cmark",
  "serde",
@@ -81,6 +82,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "digest"
@@ -174,6 +188,16 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -388,6 +412,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
+chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in isolation from executed files like templates.
 
 ## Creating Content for Bartholomew
 
-Bartholomew content consists of Markdown documents with TOML headers (aka _frontmatter_):
+Bartholomew content consists of Markdown documents with TOML headers (aka _Front Matter_):
 
 ```
 title = "This is the title"
@@ -96,10 +96,14 @@ This is the markdown content
 Bartholomew supports Markdown via the [Pulldown-Cmark](https://crates.io/crates/pulldown_cmark)
 library.
 
-### Frontmatter
+### Head (Front Matter)
 
 Front matter is fairly basic, limited to a few predefined entries, and a map of custom
-name/value pairs:
+name/value pairs. In Bartholomew, we refer to front matter as `head` (_the header_) for brevity.
+So you can think of every piece of content as having a _head_ and a _body_.
+(Shoulders, knees, and toes will be added in a forthcoming release.)
+
+A typical `head` looks like this:
 
 ```
 title = "The title"
@@ -127,14 +131,14 @@ accessible by its relative name, minus the extension. For example. `templates/ma
 will be accessible as `main`.
 
 Note that Bartholomew _expects_ to find a template named `main`. This template is used as
-a default when the content frontmatter does not contain a `template` directive. It is also
+a default when the content head does not contain a `template` directive. It is also
 used when an error occurs. You must have a `main` template.
 
-### Accessing Frontmatter
+### Accessing The Head (Front Matter) and the Body
 
-Frontmatter is available in the template using the `{{ page.frontmatter }}` object.
-For example, to print the title, use `{{ page.frontmatter.title }}`. To access your custom
-`[extra]` field named `foo`, use `{{ page.frontmatter.extra.foo }}`.
+The head is available in the template using the `{{ page.head }}` object.
+For example, to print the title, use `{{ page.head.title }}`. To access your custom
+`[extra]` field named `foo`, use `{{ page.head.extra.foo }}`.
 
 The body is injected to the template converted to HTML. That is, the template does not
 have access to the Markdown version of the document.

--- a/content/docs/config.md
+++ b/content/docs/config.md
@@ -3,7 +3,7 @@ description = "You can change site-wide settings in config.toml"
 ---
 
 [TOML](https://toml.io/en/) is a simple configuration format.
-Bartholomew uses TOML for [frontmatter in Markdown documents](markdown) as well as
+Bartholomew uses TOML for [the `head` in Markdown documents](markdown) as well as
 in the site configuration. In this chapter, we will focus on site configuration.
 
 Your site's `config/` directory has one configuration file in it, called `site.toml`:
@@ -20,7 +20,7 @@ github = "https://github.com/technosophos/bartholomew"
 twitter = "https://twitter.com/technosophos"
 ```
 
-You can think of this as "frontmatter for your site".
+You can think of this as "header for your site".
 
 It has a few pre-defined fields:
 

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -17,7 +17,7 @@ Here is a simple HTML template with Handlebars:
 <html>
 
 <head>
-    <title>{{page.frontmatter.title}}</title>
+    <title>{{page.head.title}}</title>
 </head>
 
 <body>
@@ -27,7 +27,7 @@ Here is a simple HTML template with Handlebars:
 </html>
 ```
 
-The above sets the HTML document's title to whatever is in `page.frontmatter.title`, and
+The above sets the HTML document's title to whatever is in `page.head.title`, and
 then fills in the `body` with the value of `page.body`.
 
 Let's take a brief look at the `page` object to understand what is happening here.
@@ -38,7 +38,7 @@ In JSON, the `page` object looks like this:
 
 ```
 {
-    frontmatter: {
+    head: {
         title: "Some title",
         description: "Some description",
         template: "an optional template rather than using main.hbs"
@@ -52,7 +52,7 @@ In JSON, the `page` object looks like this:
 ```
 
 To access a part, you simply use a dotted path notation. So to get the value of `key` in
-the `extra` section, we use `{{ page.frontmatter.extra.key }}`.
+the `extra` section, we use `{{ page.head.extra.key }}`.
 
 In addition to the `page` object, there is also a `site` object:
 

--- a/content/docs/rhai.md
+++ b/content/docs/rhai.md
@@ -93,7 +93,7 @@ The script returns a more complex data type, so let's see how this one is used i
 <div class="p-4">
     <h4 class="fst-italic">Recent Posts</h4>
     <ol class="list-unstyled mb-0">
-        {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.frontmatter.title}}</a></li>
+        {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.head.title}}</a></li>
         {{/each }}
     </ol>
 </div>
@@ -107,11 +107,11 @@ The value of `this` within the `#each` loop is the object that we created in Rha
 ```
 #{
     uri: "/some/path"
-    page: #{frontmatter: #{...}, body: "some html" }
+    page: #{head: #{...}, body: "some html" }
 }
 ```
 
-So `<a href="{{uri}}">{{page.frontmatter.title}}</a>` will use `this.uri`, and the `title`
+So `<a href="{{uri}}">{{page.head.title}}</a>` will use `this.uri`, and the `title`
 from the `page` object.
 
 That's how you can use Rhai to add custom formatters to the site.

--- a/src/content.rs
+++ b/src/content.rs
@@ -11,7 +11,7 @@ use crate::template::PageValues;
 const DOC_SEPERATOR: &str = "\n---\n";
 
 #[derive(Deserialize, Serialize)]
-pub struct Frontmatter {
+pub struct Head {
     /// The title of the document
     pub title: String,
     /// A short description of the document
@@ -69,7 +69,7 @@ fn visit_files(dir: PathBuf, cb: &mut dyn FnMut(&DirEntry)) -> anyhow::Result<()
 }
 
 pub struct Content {
-    pub frontmatter: Frontmatter,
+    pub head: Head,
     pub body: String,
 }
 
@@ -93,9 +93,9 @@ impl FromStr for Content {
         let (toml_text, body) = full_document
             .split_once(DOC_SEPERATOR)
             .unwrap_or(("title = 'Untitled'", &full_document));
-        let frontmatter: Frontmatter = toml::from_str(toml_text)?;
+        let head: Head = toml::from_str(toml_text)?;
         Ok(Content {
-            frontmatter,
+            head,
             body: body.to_owned(),
         })
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use super::content::{Content, Frontmatter};
+use super::content::{Content, Head};
 use handlebars::{
     handlebars_helper, Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError,
 };
@@ -39,7 +39,7 @@ pub struct SiteValues {
 /// The body should be legal HTML that can be inserted within the <body> tag.
 #[derive(Serialize)]
 pub struct PageValues {
-    pub frontmatter: Frontmatter,
+    pub head: Head,
     pub body: String,
 }
 
@@ -47,7 +47,7 @@ impl From<Content> for PageValues {
     fn from(c: Content) -> Self {
         PageValues {
             body: c.render_markdown(),
-            frontmatter: c.frontmatter,
+            head: c.head,
         }
     }
 }
@@ -103,7 +103,7 @@ impl<'a> Renderer<'a> {
     ) -> anyhow::Result<String> {
         let page: PageValues = values.into();
         let tpl = page
-            .frontmatter
+            .head
             .template
             .clone()
             .unwrap_or_else(|| DEFAULT_TEMPLATE.to_owned());
@@ -118,7 +118,7 @@ impl<'a> Renderer<'a> {
                 // seriously, this is probably not the best thing to do.
                 //
                 // Options:
-                // 1. Parse only the frontmatter out of pages
+                // 1. Parse only the head out of pages
                 // 2. Get all of the content paths, but load lazily (perhaps by helper)
                 // 3. ???
                 // 4. Leave it like it is
@@ -136,7 +136,7 @@ impl<'a> Renderer<'a> {
 
         //let cdir = self.content_dir.clone();
         // TODO: Don't capture the error.
-        //handlebars_helper!(frontmatter: |p: String| crate::content::load_frontmatter(p).unwrap_or_else(Frontmatter{}));
+        //handlebars_helper!(head: |p: String| crate::content::load_head(p).unwrap_or_else(Head{}));
         handlebars_helper!(upper: |s: String| s.to_uppercase());
         handlebars_helper!(lower: |s: String| s.to_lowercase());
         /*handlebars_helper!(pages: |_| {
@@ -146,7 +146,7 @@ impl<'a> Renderer<'a> {
         self.handlebars.register_helper("upper", Box::new(upper));
         self.handlebars.register_helper("lower", Box::new(lower));
         //self.handlebars
-        //    .register_helper("frontmatter", Box::new(frontmatter));
+        //    .register_helper("head", Box::new(head));
     }
 }
 
@@ -174,7 +174,7 @@ fn pages_helper(
 /// end user.
 pub fn error_values(title: &str, msg: &str) -> PageValues {
     PageValues {
-        frontmatter: Frontmatter {
+        head: Head {
             title: title.to_string(),
             description: None,
             extra: None,

--- a/templates/author.hbs
+++ b/templates/author.hbs
@@ -4,12 +4,12 @@
     <div class="card mb-3">
         <div class="row g-0">
             <div class="col-md-4">
-                <img src="{{page.frontmatter.extra.author_image}}" class="img-fluid rounded-start"
-                    alt="{{page.frontmatter.title}}">
+                <img src="{{page.head.extra.author_image}}" class="img-fluid rounded-start"
+                    alt="{{page.head.title}}">
             </div>
             <div class="col-md-8">
                 <div class="card-body">
-                    <h5 class="card-title">{{page.frontmatter.title}}</h5>
+                    <h5 class="card-title">{{page.head.title}}</h5>
                     <div class="card-text">
                         {{{page.body}}}
                     </div>

--- a/templates/blog.hbs
+++ b/templates/blog.hbs
@@ -4,7 +4,7 @@
 
     {{#each (blogs site.pages)}}
     <article class="blog-post">
-        {{#with page.frontmatter}}
+        {{#with page.head}}
         <h1 class="blog-post-title border-bottom">{{title}}</h2>
             <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}

--- a/templates/content_sidebar.hbs
+++ b/templates/content_sidebar.hbs
@@ -8,7 +8,7 @@
         <div class="p-4">
             <h4 class="fst-italic">Recent Posts</h4>
             <ol class="list-unstyled mb-0">
-                {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.frontmatter.title}}</a></li>
+                {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.head.title}}</a></li>
                 {{/each }}
             </ol>
         </div>

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -3,10 +3,10 @@
 
 <head>
     {{! Use the formatter.title and formatter.description in the head }}
-    <title>{{page.frontmatter.title}} | {{site.info.title}}</title>
-    {{#if page.frontmatter.description}}
+    <title>{{page.head.title}} | {{site.info.title}}</title>
+    {{#if page.head.description}}
     {{! Only render the description if it exists }}
-    <meta name="description" content="{{page.frontmatter.description}}">
+    <meta name="description" content="{{page.head.description}}">
     {{/if}}
     <!-- Twitter Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/templates/helpers.hbs
+++ b/templates/helpers.hbs
@@ -2,18 +2,18 @@
 <html>
 
 <head>
-    <title>{{page.frontmatter.title}}</title>
+    <title>{{page.head.title}}</title>
 </head>
 
 <body>
     <ul>
-        <li>upper: {{upper page.frontmatter.title}}</li>
-        <li>lower: {{lower page.frontmatter.title}}</li>
+        <li>upper: {{upper page.head.title}}</li>
+        <li>lower: {{lower page.head.title}}</li>
     </ul>
     <h2>Pages</h2>
     <ul>
         {{#each site.pages }}
-        <li>{{@key}}: {{this.frontmatter.title}}</li>
+        <li>{{@key}}: {{this.head.title}}</li>
         {{/each}}
     </ul>
 

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -2,7 +2,7 @@
 
 <div class="col-md-8">
     <article class="blog-post">
-        {{#with page.frontmatter}}
+        {{#with page.head}}
         <h1 class="blog-post-title border-bottom">{{title}}</h2>
             <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
@@ -19,27 +19,27 @@
     <div class="card-group">
         {{#with (get_page "/content/features/wasm.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>
         {{/with}}
         {{#with (get_page "/content/features/wagi.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>
         {{/with}}
         {{#with (get_page "/content/features/kiss.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>


### PR DESCRIPTION
In the original Bartholomew, the header of a Markdown document was referred to as `Frontmatter` and accessing it in the code was done via `page.frontmatter`. But that seems unnecessarily verbose, and it is also a harder word to remember.

This PR switches it over to `head`, making userland code much briefer (`page.head`).

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>