### PR TITLE
Add support for dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/modules/*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ name = "bartholomew"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "handlebars",
  "pulldown-cmark",
  "serde",
@@ -81,6 +82,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "digest"
@@ -174,6 +188,16 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -388,6 +412,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
+chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
-chrono = "0.4"
+chrono = {version = "0.4", features = ["serde"]}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
 WAGI ?= wagi
+# If PREVIEW_MODE is on then unpublished content will be displayed.
+PREVIEW_MODE ?= 0
 
 .PHONY: build
 build:
 	cargo build --target wasm32-wasi --release
+	# Keep an eye on the binary size. We want it under 5M
+	@ls -lah target/wasm32-wasi/release/*.wasm
 
 .PHONY: serve
 serve: build
 serve:
-	$(WAGI) -c ./modules.toml --log-dir ./logs
+	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=${PREVIEW_MODE}
+
+.PHONY: run
+run: serve
+
+# Quick ergonomic to create an ISO 8601 date on Mac or on Linux (Gnu date)
+.PHONY: date
+date:
+	date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in isolation from executed files like templates.
 
 ## Creating Content for Bartholomew
 
-Bartholomew content consists of Markdown documents with TOML headers (aka _frontmatter_):
+Bartholomew content consists of Markdown documents with TOML headers (aka _Front Matter_):
 
 ```
 title = "This is the title"
@@ -96,10 +96,14 @@ This is the markdown content
 Bartholomew supports Markdown via the [Pulldown-Cmark](https://crates.io/crates/pulldown_cmark)
 library.
 
-### Frontmatter
+### Head (Front Matter)
 
 Front matter is fairly basic, limited to a few predefined entries, and a map of custom
-name/value pairs:
+name/value pairs. In Bartholomew, we refer to front matter as `head` (_the header_) for brevity.
+So you can think of every piece of content as having a _head_ and a _body_.
+(Shoulders, knees, and toes will be added in a forthcoming release.)
+
+A typical `head` looks like this:
 
 ```
 title = "The title"
@@ -127,14 +131,14 @@ accessible by its relative name, minus the extension. For example. `templates/ma
 will be accessible as `main`.
 
 Note that Bartholomew _expects_ to find a template named `main`. This template is used as
-a default when the content frontmatter does not contain a `template` directive. It is also
+a default when the content head does not contain a `template` directive. It is also
 used when an error occurs. You must have a `main` template.
 
-### Accessing Frontmatter
+### Accessing The Head (Front Matter) and the Body
 
-Frontmatter is available in the template using the `{{ page.frontmatter }}` object.
-For example, to print the title, use `{{ page.frontmatter.title }}`. To access your custom
-`[extra]` field named `foo`, use `{{ page.frontmatter.extra.foo }}`.
+The head is available in the template using the `{{ page.head }}` object.
+For example, to print the title, use `{{ page.head.title }}`. To access your custom
+`[extra]` field named `foo`, use `{{ page.head.extra.foo }}`.
 
 The body is injected to the template converted to HTML. That is, the template does not
 have access to the Markdown version of the document.

--- a/README.md
+++ b/README.md
@@ -19,12 +19,29 @@ To run Bartholomew, you will need a Wagi-capable runtime.
 For example, you can just download a recent release of [Wagi](https://github.com/deislabs/wagi) and put it on your `$PATH`.
 Then the `make serve` command can start it all up for you.
 
+### Install the Fileserver
+
+Bartholomew uses an external file server called [Wagi-Fileserver](https://github.com/deislabs/wagi-fileserver/releases).
+
+Download the latest release and put it in the `modules/` directory. When you are done, you should see:
+
+```consle
+$ ls modules                                 
+README.md          fileserver.gr.wasm
+```
+
 ## Running Bartholomew
 
 With Wagi:
 
 ```
 $ wagi -c modules.toml
+```
+
+With `make`:
+
+```
+$ make serve
 ```
 
 With Hippo:
@@ -34,6 +51,32 @@ $ hippo push
 ```
 
 For convenience, `make serve` builds the code, and then runs `wagi -c`.
+
+### Preview Mode
+
+By default, Bartholomew will not display content that is unpublished.
+Content is unpublished if either:
+
+- The article is marked `published = false` in its head
+- The article has a publish date in the future
+
+To view unpublished content, turn on `PREVIEW_MODE`.
+
+Wagi:
+
+```
+$ wagi -c modules.toml -e PREVIEW_MODE=1
+```
+
+Make:
+
+```
+$ PREVIEW_MODE=1 make serve
+```
+
+Hippo:
+
+Add the environment variable PREVIEW_MODE=1 to the desired channel.
 
 ## Configuring Bartholomew
 
@@ -80,6 +123,7 @@ Bartholomew content consists of Markdown documents with TOML headers (aka _Front
 ```
 title = "This is the title"
 description = "A quick description of the article"
+date = "2021-12-23T23:20:57Z"
 
 [extra]
 info = "The [extra] section is for your own custom metadata fields. You can use them in templates."
@@ -108,6 +152,7 @@ A typical `head` looks like this:
 ```
 title = "The title"
 description = "A short description"
+date = "2021-12-23T23:20:57Z"
 template = "main" # The default is `main`, which correlates to `templates/main.hbs`
 
 [extra]

--- a/config/site.toml
+++ b/config/site.toml
@@ -5,5 +5,8 @@ about = "This site is generated with Bartholomew, the Wagi micro-CMS. And this m
 
 [extra]
 copyright = "The Site Authors"
-github = "https://github.com/technosophos/bartholomew"
-twitter = "https://twitter.com/technosophos"
+github = "https://github.com/fermyon/bartholomew"
+twitter = "https://twitter.com/fermyontech"
+
+# Style of date to print
+date_style = "%B %e, %Y"

--- a/content/blog.md
+++ b/content/blog.md
@@ -1,5 +1,6 @@
 title = "The Bartholomew Blog"
 description = "All you need to know to get started with Bartholomew"
 template = "blog"
+date = "2021-12-23T17:05:19Z"
 ---
 A blog about Bartholomew, the simple CMS for [Wagi](https://github.com/deislabs/wagi).

--- a/content/blog/2021-12-23-first-post.md
+++ b/content/blog/2021-12-23-first-post.md
@@ -1,7 +1,7 @@
 title = "First Post!"
 description = "An example of blogging on the Bartholomew platform"
+date = "2021-12-23T15:05:19Z"
 [extra]
-date = "Aug. 1, 2021"
 author = "Matt Butcher"
 author_page = "/author/butcher"
 ---

--- a/content/blog/2021-12-23-goals-of-bartholomew.md
+++ b/content/blog/2021-12-23-goals-of-bartholomew.md
@@ -1,8 +1,7 @@
 title = "The Goals of Bartholomew"
 description = "We have plans. Big plans. Actually, they're small plans."
-
+date = "2021-12-23T17:05:19Z"
 [extra]
-date = "Aug. 31, 2021"
 author = "Matt Butcher"
 author_page = "/author/butcher"
 ---

--- a/content/blog/2021-12-23-what-is-markdown.md
+++ b/content/blog/2021-12-23-what-is-markdown.md
@@ -1,7 +1,7 @@
 title = "What Is Markdown?"
 description = "Introducing an easy-to-write document format"
+date = "2021-12-23T16:05:19Z"
 [extra]
-date = "Aug. 15, 2021"
 author = "Matt Butcher"
 author_page = "/author/butcher"
 ---

--- a/content/docs/config.md
+++ b/content/docs/config.md
@@ -3,7 +3,7 @@ description = "You can change site-wide settings in config.toml"
 ---
 
 [TOML](https://toml.io/en/) is a simple configuration format.
-Bartholomew uses TOML for [frontmatter in Markdown documents](markdown) as well as
+Bartholomew uses TOML for [the `head` in Markdown documents](markdown) as well as
 in the site configuration. In this chapter, we will focus on site configuration.
 
 Your site's `config/` directory has one configuration file in it, called `site.toml`:
@@ -20,7 +20,7 @@ github = "https://github.com/technosophos/bartholomew"
 twitter = "https://twitter.com/technosophos"
 ```
 
-You can think of this as "frontmatter for your site".
+You can think of this as "header for your site".
 
 It has a few pre-defined fields:
 

--- a/content/docs/config.md
+++ b/content/docs/config.md
@@ -1,5 +1,6 @@
 title = "Editing the Configuration File"
 description = "You can change site-wide settings in config.toml"
+date = "2021-12-23T17:05:19Z"
 ---
 
 [TOML](https://toml.io/en/) is a simple configuration format.

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -1,5 +1,6 @@
 title = "Templating with Handlebars"
 description = "Use Handlebars to customize the look and feel of your site"
+date = "2021-12-23T17:05:19Z"
 ---
 In Bartholomew, layout is handled via templates. All templates are in the
 `templates/` directory.
@@ -91,12 +92,20 @@ Note that we drop the `.hbs` suffix when including this way.
 
 There are a few template helpers define in Bartholomew.
 
-For example, to change a piece of text to all-caps, use the `uppercase` helper:
+For example, to change a piece of text to all-caps, use the `upper` helper:
 
 ```
-{{ uppercase "hello" }}
+{{ upper "hello" }}
 ```
 
 The above will render `HELLO`.
 
 Note that you can create custom template helpers using [Rhai scripts](/docs/rhai).
+
+### Defined Helper Functions
+
+The following helper functions are provided with Bartholomew
+
+- `upper STRING`: converts the given string to uppercase
+- `lower STRING`: converts the given string to lowercase
+- `date_format STRING DATE`: Formats a date using the given string. `date "%Y" page.head.date`. Use [strftime format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers).

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -14,7 +14,7 @@ it works almost identically.
 Here is a simple HTML template with Handlebars:
 
 ```
-!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -48,12 +48,15 @@ In JSON, the `page` object looks like this:
             "description": "whatever is in the [extra] section of your Markdown doc's header"
         }
     },
-    body: "<p>Some rendered Markdown content</p>"
+    body: "<p>Some rendered Markdown content</p>",
+    published: true
 }
 ```
 
 To access a part, you simply use a dotted path notation. So to get the value of `key` in
 the `extra` section, we use `{{ page.head.extra.key }}`.
+
+### The Site Object
 
 In addition to the `page` object, there is also a `site` object:
 

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -17,7 +17,7 @@ Here is a simple HTML template with Handlebars:
 <html>
 
 <head>
-    <title>{{page.frontmatter.title}}</title>
+    <title>{{page.head.title}}</title>
 </head>
 
 <body>
@@ -27,7 +27,7 @@ Here is a simple HTML template with Handlebars:
 </html>
 ```
 
-The above sets the HTML document's title to whatever is in `page.frontmatter.title`, and
+The above sets the HTML document's title to whatever is in `page.head.title`, and
 then fills in the `body` with the value of `page.body`.
 
 Let's take a brief look at the `page` object to understand what is happening here.
@@ -38,7 +38,7 @@ In JSON, the `page` object looks like this:
 
 ```
 {
-    frontmatter: {
+    head: {
         title: "Some title",
         description: "Some description",
         template: "an optional template rather than using main.hbs"
@@ -52,7 +52,7 @@ In JSON, the `page` object looks like this:
 ```
 
 To access a part, you simply use a dotted path notation. So to get the value of `key` in
-the `extra` section, we use `{{ page.frontmatter.extra.key }}`.
+the `extra` section, we use `{{ page.head.extra.key }}`.
 
 In addition to the `page` object, there is also a `site` object:
 

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,4 +1,5 @@
 title = "Documentation"
+date = "2021-12-22T17:05:19Z"
 ---
 
 Bartholomew is a content manager that takes documents written in Markdown,

--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -3,12 +3,60 @@ description = "Write your content in a simple text language"
 date = "2021-12-23T17:05:19Z"
 ---
 
+To write content for a Bartholomew website, there are three steps:
+
+1. Create the new file in the `content` directory
+1. Add front matter in the head section
+1. Write the body
+
+## Creating a New File
+
 To create a new document, just drop a file into the `content/` folder, and make sure
 that file has the extension `.md`. For example, `/content/foo.md` is a new document.
 That document is then available to Bartholomew as `/foo`. So when a user types
 `http://example.com/foo`, Bartholomew will load the file `/content/foo.md`.
 
 > The content directory can have subdirectories.
+
+## Adding Front Matter to the Document Head
+
+The first part of any Bartholomew document is the _head_. This is formatted as TOML, which for the most part is just names and values.
+
+Here is an example head:
+
+```
+title = "A New Article"
+description = "This article is really interesting and full of useful material."
+date = "2021-12-23T15:05:19Z"
+template = "post"
+
+[extra]
+author = "Matt Butcher"
+author_page = "/author/butcher"
+
+---
+```
+
+The last line of the example above is very important. The `---` tells Bartholomew that the head is done, and the body is coming up.
+
+Every head must have a `title`. It is _strongly_ recommended that it also have a `date` as well, because dates are tied to some of Bartholomew's features.
+There are several other defined fields. When you want to add your own fields, put them after the `[extra]` marker.
+You can add your own fields as name/value pairs. Just make sure you quote the values.
+
+The following fields are defined for Bartholomew:
+
+- `title`: The name of the piece of content. This is REQUIRED.
+- `date`: The date that this post is published. This can be a future date (in which case Bartholomew will not publish it until that date). It MUST be in ISO 8601 format. It is STRONGLY RECOMMENDED.
+- `description`: A short description of the content. This should be no more than a few sentences. It is RECOMMENDED.
+- `template`: The name of the template that should be used to render this content. It is OPTIONAL and defaults to `main` (`templates/main.hbs`).
+- `published`: A boolean (`published = true` or `published = false`, no quotes) that explicitly sets publication status. It is OPTIONAL and should be used sparingly.
+- `[extra]`: The section marker that indicates that all content after it is user-defined.
+    - Fields under extra MUST be in the form `name = "value"`. All values must be strings.
+    - once the `[extra]` section is declared, you cannot declare top-level fields anymore.
+
+After the `---`, you can write the content's body in Markdown.
+
+## Writing a Markdown Body
 
 All documents in Bartholomew are written in Markdown.
 [Markdown]() is a simple text format designed to make it easy (and very fast)
@@ -50,3 +98,13 @@ Say [Hello](http://example.com).
 
 If you want to reference an image, just add `!` in front of the square bracket. In that
 situation, the text in the square brackets becomes the image description.
+
+## Why Is Markdown the Only Supported Format?
+
+Some static site generators allow you to use other formats like asciidoc.
+Bartholomew only supports Markdown.
+The reason for this is pragmatic: We are trying to keep the binary size as small as we can to make Bartholomew faster.
+
+## Can I Embed HTML?
+
+Yes, you can embed HTML tags inside of your Markdown.

--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -1,5 +1,6 @@
 title = "Writing Content in Markdown"
 description = "Write your content in a simple text language"
+date = "2021-12-23T17:05:19Z"
 ---
 
 To create a new document, just drop a file into the `content/` folder, and make sure
@@ -16,8 +17,7 @@ to write text that can then be converted into HTML.
 For example, the Markdown `*hello*` is transformed into *hello*. And the Markdown
 `[example](http://example.com)` is transformed into the link [example](http://example.com).
 
-To make
-a header, you just use hash marks: `#` for a title, `##` for a sub-header, and so on.
+To make a header, you just use hash marks: `#` for a title, `##` for a sub-header, and so on.
 Bullet lists are just plain text hyphen or asterisk lists.
 
 For example:

--- a/content/docs/rhai.md
+++ b/content/docs/rhai.md
@@ -1,5 +1,6 @@
 title = "Scripting with Rhai"
 description = "Bartholomew supports custom handlebars helpers with the Rhai language"
+date = "2021-12-23T17:05:19Z"
 ---
 
 Sometimes you want to do something special in your templates. Perhaps it's some

--- a/content/docs/rhai.md
+++ b/content/docs/rhai.md
@@ -93,7 +93,7 @@ The script returns a more complex data type, so let's see how this one is used i
 <div class="p-4">
     <h4 class="fst-italic">Recent Posts</h4>
     <ol class="list-unstyled mb-0">
-        {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.frontmatter.title}}</a></li>
+        {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.head.title}}</a></li>
         {{/each }}
     </ol>
 </div>
@@ -107,11 +107,11 @@ The value of `this` within the `#each` loop is the object that we created in Rha
 ```
 #{
     uri: "/some/path"
-    page: #{frontmatter: #{...}, body: "some html" }
+    page: #{head: #{...}, body: "some html" }
 }
 ```
 
-So `<a href="{{uri}}">{{page.frontmatter.title}}</a>` will use `this.uri`, and the `title`
+So `<a href="{{uri}}">{{page.head.title}}</a>` will use `this.uri`, and the `title`
 from the `page` object.
 
 That's how you can use Rhai to add custom formatters to the site.

--- a/content/helpers_example.md
+++ b/content/helpers_example.md
@@ -1,3 +1,4 @@
 title = "Example helpers"
 template = "helpers"
+date = "2021-12-23T17:05:19Z"
 ---

--- a/content/index.md
+++ b/content/index.md
@@ -5,6 +5,7 @@ description = "The Micro-CMS for Wagi"
 date = "Aug. 30, 2021"
 author = "Matt Butcher"
 author_page = "/author/butcher"
+date = "2021-12-23T17:05:19Z"
 ---
 It might be hard to spell, but fortunately you won't have to spell it that often.
 

--- a/content/index.md
+++ b/content/index.md
@@ -23,7 +23,7 @@ Wagi, Hippo, and Wagi.Net.
       <div class="card-body">
         <h5 class="card-title">Content Is Markdown</h5>
         <p class="card-text">Write your content in Markdown, the simple text-based markup language.
-Just drop your content somewhere in the `content/` folder, and you're ready to go.</p>
+Just drop your content somewhere in the <code>content/</code> folder, and you're ready to go.</p>
         <p class="card-text"><small class="text-muted">Learn More</small></p>
       </div>
     </div>
@@ -39,7 +39,7 @@ Just drop your content somewhere in the `content/` folder, and you're ready to g
       <div class="card-body">
         <h5 class="card-title">Templates are Handlebars</h5>
         <p class="card-text">Handlebars is a popular template format similar to Mustache. All of the templates
-are fully customizable. You can take a look in the `templates/` directory to start
+are fully customizable. You can take a look in the <code>templates/</code> directory to start
 customizing the look and feel of this site.</p>
         <p class="card-text"><small class="text-muted">Learn More</small></p>
       </div>
@@ -55,7 +55,7 @@ customizing the look and feel of this site.</p>
     <div class="col-md-8">
       <div class="card-body">
         <h5 class="card-title">Defaults to Twitter Bootstrap</h5>
-        <p class="card-text">The theme that ships with Bartholomew is just a simple [Twitter Bootstrap](https://getbootstrap.com/) theme.</p>
+        <p class="card-text">The theme that ships with Bartholomew is just a simple <a href="https://getbootstrap.com/">Twitter Bootstrap</a> theme.</p>
         <p class="card-text"><small class="text-muted">Learn More</small></p>
       </div>
     </div>
@@ -70,8 +70,8 @@ customizing the look and feel of this site.</p>
     <div class="col-md-8">
       <div class="card-body">
         <h5 class="card-title">Simple TOML Config Files</h5>
-        <p class="card-text">Configuration files are in `config`, and are simple TOML files. Probably the only one
-you need is `config/site.toml`.
+        <p class="card-text">Configuration files are in <code>config/</code>, and are simple TOML files. Probably the only one
+you need is <code>config/site.toml</code>.
 </p>
         <p class="card-text"><small class="text-muted">Learn More</small></p>
       </div>

--- a/content/markdown.md
+++ b/content/markdown.md
@@ -1,5 +1,6 @@
 title = "Markdown examples"
 description = "Examples of using Markdown syntax inside of a page"
+date = "2021-12-23T17:05:19Z"
 ---
 
 # Header 1

--- a/modules.toml
+++ b/modules.toml
@@ -1,5 +1,5 @@
 [[module]]
-module = "/Users/technosophos/Code/Grain/fileserver/fileserver.gr.wasm"
+module = "modules/fileserver.gr.wasm"
 route = "/static/..."
 volumes = {"/" = "static/"}
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,5 @@
+# Modules
+
+Third-party Wasm modules should go in this directory.
+
+Note that anything ending in `.wasm` will be ignored by Git.

--- a/scripts/blogs.rhai
+++ b/scripts/blogs.rhai
@@ -19,15 +19,28 @@ for item in keys {
     if item.index_of("/content/blog/") == 0 {
         // Remove /content and .md
         let path = item.sub_string(8);
+        let page = pages[item];
+
         path = path.sub_string(0, path.index_of(".md"));
         blog_pages.push(#{
             uri: path,
-            page: pages[item],
+            page: page,
         });
         //blog_pages[path] = pages[item];
     }
    
 }
-// Newest to oldest, assuming you put the date in the URI
-blog_pages.reverse();
+
+// Return the blogs sorted newest to oldest
+fn sort_by_date(a, b) {
+    if a.page.head.date < b.page.head.date {
+        1
+    } else {
+        -1
+    }
+}
+
+// Sort by the value of the page date.
+blog_pages.sort(Fn("sort_by_date"));
+
 blog_pages

--- a/src/content.rs
+++ b/src/content.rs
@@ -11,7 +11,7 @@ use crate::template::PageValues;
 const DOC_SEPERATOR: &str = "\n---\n";
 
 #[derive(Deserialize, Serialize)]
-pub struct Frontmatter {
+pub struct Head {
     /// The title of the document
     pub title: String,
     /// A short description of the document
@@ -69,7 +69,7 @@ fn visit_files(dir: PathBuf, cb: &mut dyn FnMut(&DirEntry)) -> anyhow::Result<()
 }
 
 pub struct Content {
-    pub frontmatter: Frontmatter,
+    pub head: Head,
     pub body: String,
 }
 
@@ -93,9 +93,9 @@ impl FromStr for Content {
         let (toml_text, body) = full_document
             .split_once(DOC_SEPERATOR)
             .unwrap_or(("title = 'Untitled'", &full_document));
-        let frontmatter: Frontmatter = toml::from_str(toml_text)?;
+        let head: Head = toml::from_str(toml_text)?;
         Ok(Content {
-            frontmatter,
+            head,
             body: body.to_owned(),
         })
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use super::content::{Content, Frontmatter};
+use super::content::{Content, Head};
 use handlebars::{
     handlebars_helper, Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError,
 };
@@ -39,7 +39,7 @@ pub struct SiteValues {
 /// The body should be legal HTML that can be inserted within the <body> tag.
 #[derive(Serialize)]
 pub struct PageValues {
-    pub frontmatter: Frontmatter,
+    pub head: Head,
     pub body: String,
 }
 
@@ -47,7 +47,7 @@ impl From<Content> for PageValues {
     fn from(c: Content) -> Self {
         PageValues {
             body: c.render_markdown(),
-            frontmatter: c.frontmatter,
+            head: c.head,
         }
     }
 }
@@ -103,7 +103,7 @@ impl<'a> Renderer<'a> {
     ) -> anyhow::Result<String> {
         let page: PageValues = values.into();
         let tpl = page
-            .frontmatter
+            .head
             .template
             .clone()
             .unwrap_or_else(|| DEFAULT_TEMPLATE.to_owned());
@@ -118,7 +118,7 @@ impl<'a> Renderer<'a> {
                 // seriously, this is probably not the best thing to do.
                 //
                 // Options:
-                // 1. Parse only the frontmatter out of pages
+                // 1. Parse only the head out of pages
                 // 2. Get all of the content paths, but load lazily (perhaps by helper)
                 // 3. ???
                 // 4. Leave it like it is
@@ -136,7 +136,7 @@ impl<'a> Renderer<'a> {
 
         //let cdir = self.content_dir.clone();
         // TODO: Don't capture the error.
-        //handlebars_helper!(frontmatter: |p: String| crate::content::load_frontmatter(p).unwrap_or_else(Frontmatter{}));
+        //handlebars_helper!(head: |p: String| crate::content::load_head(p).unwrap_or_else(Head{}));
         handlebars_helper!(upper: |s: String| s.to_uppercase());
         handlebars_helper!(lower: |s: String| s.to_lowercase());
         /*handlebars_helper!(pages: |_| {
@@ -146,7 +146,7 @@ impl<'a> Renderer<'a> {
         self.handlebars.register_helper("upper", Box::new(upper));
         self.handlebars.register_helper("lower", Box::new(lower));
         //self.handlebars
-        //    .register_helper("frontmatter", Box::new(frontmatter));
+        //    .register_helper("head", Box::new(head));
     }
 }
 
@@ -174,7 +174,7 @@ fn pages_helper(
 /// end user.
 pub fn error_values(title: &str, msg: &str) -> PageValues {
     PageValues {
-        frontmatter: Frontmatter {
+        head: Head {
             title: title.to_string(),
             description: None,
             extra: None,

--- a/templates/author.hbs
+++ b/templates/author.hbs
@@ -4,12 +4,12 @@
     <div class="card mb-3">
         <div class="row g-0">
             <div class="col-md-4">
-                <img src="{{page.frontmatter.extra.author_image}}" class="img-fluid rounded-start"
-                    alt="{{page.frontmatter.title}}">
+                <img src="{{page.head.extra.author_image}}" class="img-fluid rounded-start"
+                    alt="{{page.head.title}}">
             </div>
             <div class="col-md-8">
                 <div class="card-body">
-                    <h5 class="card-title">{{page.frontmatter.title}}</h5>
+                    <h5 class="card-title">{{page.head.title}}</h5>
                     <div class="card-text">
                         {{{page.body}}}
                     </div>

--- a/templates/blog.hbs
+++ b/templates/blog.hbs
@@ -5,8 +5,10 @@
     {{#each (blogs site.pages)}}
     <article class="blog-post">
         {{#with page.head}}
-        <h1 class="blog-post-title border-bottom">{{title}}</h2>
-            <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
+        <h1 class="blog-post-title border-bottom">{{title}}</h1>
+            <p class="blog-post-meta">
+                {{#if date }}{{date_format "%Y-%m-%d" date}} {{/if}}
+                {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
             </p>
             {{/with}}

--- a/templates/blog.hbs
+++ b/templates/blog.hbs
@@ -4,14 +4,12 @@
 
     {{#each (blogs site.pages)}}
     <article class="blog-post">
-        {{#with page.head}}
-        <h1 class="blog-post-title border-bottom">{{title}}</h1>
+        <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
             <p class="blog-post-meta">
-                {{#if date }}{{date_format "%Y-%m-%d" date}} {{/if}}
-                {{#if extra.author}} by <a
-                    href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
+                {{#if page.head.date }}{{date_format ../site.info.extra.date_style page.head.date}} {{/if}}
+                {{#if page.head.extra.author}} by <a
+                    href="{{page.head.extra.author_page}}">{{page.head.extra.author}}</a>{{/if}}
             </p>
-            {{/with}}
             {{! Since this is HTML, we use the triple-curly }}
             {{{page.body}}}
             <p><a href="{{this.uri}}">View the Post</a></p>

--- a/templates/blog.hbs
+++ b/templates/blog.hbs
@@ -4,7 +4,7 @@
 
     {{#each (blogs site.pages)}}
     <article class="blog-post">
-        {{#with page.frontmatter}}
+        {{#with page.head}}
         <h1 class="blog-post-title border-bottom">{{title}}</h2>
             <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}

--- a/templates/content_sidebar.hbs
+++ b/templates/content_sidebar.hbs
@@ -8,7 +8,7 @@
         <div class="p-4">
             <h4 class="fst-italic">Recent Posts</h4>
             <ol class="list-unstyled mb-0">
-                {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.frontmatter.title}}</a></li>
+                {{#each (blogs site.pages)}}<li><a href="{{uri}}">{{page.head.title}}</a></li>
                 {{/each }}
             </ol>
         </div>

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -3,10 +3,10 @@
 
 <head>
     {{! Use the formatter.title and formatter.description in the head }}
-    <title>{{page.frontmatter.title}} | {{site.info.title}}</title>
-    {{#if page.frontmatter.description}}
+    <title>{{page.head.title}} | {{site.info.title}}</title>
+    {{#if page.head.description}}
     {{! Only render the description if it exists }}
-    <meta name="description" content="{{page.frontmatter.description}}">
+    <meta name="description" content="{{page.head.description}}">
     {{/if}}
     <!-- Twitter Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -30,6 +30,10 @@
         .learn-more-card-group {
             margin-top: 2em;
         }
+
+        pre {
+            background-color: #efefef;
+        }
     </style>
 </head>
 

--- a/templates/helpers.hbs
+++ b/templates/helpers.hbs
@@ -2,18 +2,18 @@
 <html>
 
 <head>
-    <title>{{page.frontmatter.title}}</title>
+    <title>{{page.head.title}}</title>
 </head>
 
 <body>
     <ul>
-        <li>upper: {{upper page.frontmatter.title}}</li>
-        <li>lower: {{lower page.frontmatter.title}}</li>
+        <li>upper: {{upper page.head.title}}</li>
+        <li>lower: {{lower page.head.title}}</li>
     </ul>
     <h2>Pages</h2>
     <ul>
         {{#each site.pages }}
-        <li>{{@key}}: {{this.frontmatter.title}}</li>
+        <li>{{@key}}: {{this.head.title}}</li>
         {{/each}}
     </ul>
 

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -8,16 +8,14 @@ This content is unpublished.
 
 <div class="col-md-8">
     <article class="blog-post">
-        {{#with page.head}}
-        <h1 class="blog-post-title border-bottom">{{title}}</h2>
-            <p class="blog-post-meta">{{date}} {{#if extra.author}} by <a
-                    href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
+        <h1 class="blog-post-title border-bottom">{{page.head.title}}</h1>
+            <p class="blog-post-meta">
+                {{#if page.head.date}}{{date_format site.info.extra.date_style page.head.date}} {{/if}}
+                {{#if page.head.extra.author}} by <a
+                    href="{{page.head.extra.author_page}}">{{page.head.extra.author}}</a>{{/if}}
             </p>
-            {{/with}}
             {{! Since this is HTML, we use the triple-curly }}
             {{{page.body}}}
-            {{ echo "world" }}
-
     </article>
 
 

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -1,10 +1,16 @@
 {{> content_top }}
 
+{{#if page.published }}{{else}}
+<div class="col-md-8 alert alert-warning" role="alert">
+This content is unpublished.
+</div>
+{{/if}}
+
 <div class="col-md-8">
     <article class="blog-post">
         {{#with page.head}}
         <h1 class="blog-post-title border-bottom">{{title}}</h2>
-            <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
+            <p class="blog-post-meta">{{date}} {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
             </p>
             {{/with}}

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -2,7 +2,7 @@
 
 <div class="col-md-8">
     <article class="blog-post">
-        {{#with page.frontmatter}}
+        {{#with page.head}}
         <h1 class="blog-post-title border-bottom">{{title}}</h2>
             <p class="blog-post-meta">{{extra.date}} {{#if extra.author}} by <a
                     href="{{extra.author_page}}">{{extra.author}}</a>{{/if}}
@@ -19,27 +19,27 @@
     <div class="card-group">
         {{#with (get_page "/content/features/wasm.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>
         {{/with}}
         {{#with (get_page "/content/features/wagi.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>
         {{/with}}
         {{#with (get_page "/content/features/kiss.md" site.pages) }}
         <div class="card">
-            <img src="{{page.frontmatter.extra.image}}" class="card-img-top" alt="{{page.frontmatter.title}}">
+            <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
-                <h5 class="card-title">{{this.page.frontmatter.title}}</h5>
+                <h5 class="card-title">{{this.page.head.title}}</h5>
                 <p class="card-text">{{{page.body}}}</p>
             </div>
         </div>


### PR DESCRIPTION
This bumps up date support to a main feature. It adds:

- a `date` field in article metadata
- a `published` field in article metadata
- `date`-aware publishing of content
- `published`-aware publishing of content
- a `PREVIEW_MODE` env var to preview unpublished content
- an improved example of the blog that uses dates to sort

The current publishing policy is:

- If an article is marked `published = false`, it is not published
- If an article has a date in the future, it is not published
- All other articles are considered published