### PR TITLE
Add helpers for tags and env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /modules/*.wasm
+/logs

--- a/content/blog/2021-12-23-first-post.md
+++ b/content/blog/2021-12-23-first-post.md
@@ -1,6 +1,7 @@
 title = "First Post!"
 description = "An example of blogging on the Bartholomew platform"
 date = "2021-12-23T15:05:19Z"
+tags = ["bartholomew", "markdown", "toml"]
 [extra]
 author = "Matt Butcher"
 author_page = "/author/butcher"

--- a/content/blog/2021-12-23-goals-of-bartholomew.md
+++ b/content/blog/2021-12-23-goals-of-bartholomew.md
@@ -1,6 +1,7 @@
 title = "The Goals of Bartholomew"
 description = "We have plans. Big plans. Actually, they're small plans."
 date = "2021-12-23T17:05:19Z"
+tags = ["bartholomew"]
 [extra]
 author = "Matt Butcher"
 author_page = "/author/butcher"

--- a/content/blog/2021-12-23-what-is-markdown.md
+++ b/content/blog/2021-12-23-what-is-markdown.md
@@ -1,6 +1,7 @@
 title = "What Is Markdown?"
 description = "Introducing an easy-to-write document format"
 date = "2021-12-23T16:05:19Z"
+tags = ["markdown", "toml", "bartholomew"]
 [extra]
 author = "Matt Butcher"
 author_page = "/author/butcher"

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -79,6 +79,37 @@ In addition to the `page` object, there is also a `site` object:
 Note that the `site.pages` array has access to every single document in the `content` folder.
 This part of the API may change in the future, as it does not scale terribly well.
 
+### The Env Object
+
+The third top-level object is `env`, which holds all of the environment data, including details about
+the HTTP request, the path of this resource, and other WAGI information.
+
+The `env` object is a set of keys and values:
+
+```
+{
+    PATH_INFO: "/hello-world"
+    ...
+}
+```
+
+The list of environment variables is long. Any environment variable that begins `HTTP_` is from the web browswer and should not be trust.
+A number of variables are [defined by Wagi](https://github.com/deislabs/wagi/blob/main/docs/environment_variables.md) and have a special meaning.
+
+You can dump the entire contents of `env` using a template like this:
+
+```
+<ul>
+    {{#each env}}
+    <li><code>{{@key}}</code>: <code>"{{this}}"</code></li>
+    {{/each}}
+</ul>
+```
+
+Or you can access an individual variable by name: `env.PATH_INFO`.
+
+Note that very little data validation is done on incoming environment variables, so you should validate or scrub any values before showing them to the user.
+
 ## Including A Template
 
 It is possible to include a template into another template.

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -93,7 +93,7 @@ The `env` object is a set of keys and values:
 }
 ```
 
-The list of environment variables is long. Any environment variable that begins `HTTP_` is from the web browswer and should not be trust.
+The list of environment variables is long. Any environment variable that begins `HTTP_` is from the web browser and should not be trusted.
 A number of variables are [defined by Wagi](https://github.com/deislabs/wagi/blob/main/docs/environment_variables.md) and have a special meaning.
 
 You can dump the entire contents of `env` using a template like this:

--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -29,6 +29,7 @@ title = "A New Article"
 description = "This article is really interesting and full of useful material."
 date = "2021-12-23T15:05:19Z"
 template = "post"
+tags = ["news", "article"]
 
 [extra]
 author = "Matt Butcher"
@@ -50,6 +51,7 @@ The following fields are defined for Bartholomew:
 - `description`: A short description of the content. This should be no more than a few sentences. It is RECOMMENDED.
 - `template`: The name of the template that should be used to render this content. It is OPTIONAL and defaults to `main` (`templates/main.hbs`).
 - `published`: A boolean (`published = true` or `published = false`, no quotes) that explicitly sets publication status. It is OPTIONAL and should be used sparingly.
+- `tags`: A list of tags. The tags should be ranked most- to least-relevant. OPTIONAL and defaults to an empty list.
 - `[extra]`: The section marker that indicates that all content after it is user-defined.
     - Fields under extra MUST be in the form `name = "value"`. All values must be strings.
     - once the `[extra]` section is declared, you cannot declare top-level fields anymore.

--- a/content/tag.md
+++ b/content/tag.md
@@ -1,0 +1,4 @@
+title = "Articles for Tag"
+date = "2021-12-24T21:31:26Z"
+template = "tag"
+---

--- a/scripts/tagged_pages.rhai
+++ b/scripts/tagged_pages.rhai
@@ -1,0 +1,53 @@
+// This function lists all pages that are tagged with the given tag.
+//
+// It returns an array of objects of the form:
+//  [
+//    #{ uri: "path/to/page", page: PageObject, weight: int }
+// ]
+
+// Param 1 should be `site.pages`
+let pages = params[0];
+
+// Param 2 should be the tag name
+let tag = params[1];
+
+// Loop through them and return all of the page objects that are in
+// the blog path.
+let tagged_pages = [];
+
+// Get each blog post, assigning it to {path: object}.
+let keys = pages.keys();
+for item in keys {
+    // Remove /content
+    let path = item.sub_string(8);
+    let page = pages[item];
+
+    if page.head.tags.len == 0 {
+        continue;
+    }
+
+    let tag_index = page.head.tags.index_of(tag);
+    if tag_index >= 0 {
+        // Remove .md
+        path = path.sub_string(0, path.index_of(".md"));
+        tagged_pages.push(#{
+            uri: path,
+            page: page,
+            weight: tag_index,
+        });
+    }
+}
+
+// Return the matches, sorted by weight
+fn sort_by_weight(a, b) {
+    if a.weight < b.weight {
+        -1
+    } else {
+        1
+    }
+}
+
+// Sort by how close to the front of the tag list a given tag was.
+tagged_pages.sort(Fn("sort_by_weight"));
+
+tagged_pages

--- a/src/content.rs
+++ b/src/content.rs
@@ -29,6 +29,14 @@ pub struct Head {
     /// If this is set, it will explicitly set the publish state of a piece of content.
     /// If this is None, then the publish state will be derived from things like date.
     pub published: Option<bool>,
+
+    /// Article tags
+    /// 
+    /// In the template language, having an Option<Vec<>> can get really confusing,
+    /// so the deserializer just creates an empty vec if not present in the source
+    /// doc.
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Given a PATH_INFO variable, transform it into a path for a specific markdown file
@@ -110,9 +118,11 @@ pub struct Content {
 
 impl Content {
 
-    // Create new content from a head and a body.
-    //
-    // This determines published state based on the head.
+    /// Create new content from a head and a body.
+    ///
+    /// This determines published state based on the head.
+    ///
+    /// The environment is copied from the system environment. This is safe when executed inside of Wagi or a WASI runtime.
     pub fn new(head: Head, body: String) -> Self {
         let pdate = head.date.clone();
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -28,6 +28,16 @@ pub struct TemplateContext {
     request: RequestValues,
     page: PageValues,
     site: SiteValues,
+    /// A copy of the environment variables
+    /// 
+    /// Unlike a static site generator, Bartholomew can make decisions based on request.
+    /// This provides templates with access to the request data along with custom
+    /// environment variables.
+    /// 
+    /// TODO: Should there be a way to filter out env vars that should never get to
+    /// the template layer? As of this writing, there are no such variables, but in
+    /// the future there could be.
+    env: BTreeMap<String, String>,
 }
 
 #[derive(Serialize)]
@@ -140,6 +150,8 @@ impl<'a> Renderer<'a> {
                 // 5. Determine that this is out of scope
                 pages: crate::content::all_pages(self.content_dir.clone(), self.show_unpublished)?,
             },
+            // Copy the WASI env into the env template var.
+            env: std::env::vars().collect(),
         };
         let out = self.handlebars.render(&tpl, &ctx)?;
         Ok(out)
@@ -203,6 +215,7 @@ pub fn error_values(title: &str, msg: &str) -> PageValues {
             extra: None,
             template: None,
             published: None,
+            tags: vec![],
         },
         body: msg.to_string(),
         published: true,

--- a/templates/helpers.hbs
+++ b/templates/helpers.hbs
@@ -16,6 +16,15 @@
         <li>{{@key}}: {{this.head.title}}</li>
         {{/each}}
     </ul>
+    <h2>Environment</h2>
+    <p>These name/value pairs are available in the <code>env</code> object</code></p>
+    <p>For example, you can fetch the value of <code>env.PATH_INFO</code>: "{{env.PATH_INFO}}"</p>
+    <p>Any value prefaced with HTTP_ is directly from the client and should not be trusted.</p>
+    <ul>
+        {{#each env}}
+        <li><code>{{@key}}</code>: <code>"{{this}}"</code></li>
+        {{/each}}
+    </ul>
 
 </body>
 

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -14,6 +14,9 @@ This content is unpublished.
                 {{#if page.head.extra.author}} by <a
                     href="{{page.head.extra.author_page}}">{{page.head.extra.author}}</a>{{/if}}
             </p>
+            <div class="tag-list">
+                {{#each page.head.tags}}<span class="badge bg-secondary ms-1"><a href="/tag?{{this}}" class="text-light">{{this}}</a></span>{{/each}}
+            </div>
             {{! Since this is HTML, we use the triple-curly }}
             {{{page.body}}}
     </article>

--- a/templates/tag.hbs
+++ b/templates/tag.hbs
@@ -1,0 +1,16 @@
+{{> content_top }}
+
+<div class="col-md-8">
+    <h1>Articles about {{env.QUERY_STRING}}</h1>
+    <p>The following articles are about {{env.QUERY_STRING}}. They are ranked most relevant to least.</p>
+
+    <ul>
+        {{#each (tagged_pages site.pages env.QUERY_STRING)}}
+        <li><a href="{{this.uri}}">{{this.page.head.title}}</a> {{this.page.head.description}}</li>
+        {{/each}}
+    </ul>
+</div>
+
+{{> content_sidebar }}
+
+{{> content_bottom }}


### PR DESCRIPTION
This PR adds the following to Bartholomew:

- A `tags` section on articles, defaulting to an empty tag list.
- A helper script for `tagged_pages` that finds and sorts pages by tag name
- Support for reading `env` from templates
- Examples of all of the above
- Documentation

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>