### PR TITLE
Improved error messages throughout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 WAGI ?= wagi
 # If PREVIEW_MODE is on then unpublished content will be displayed.
 PREVIEW_MODE ?= 0
+SHOW_DEBUG ?= 1
 
 .PHONY: build
 build:
@@ -11,7 +12,7 @@ build:
 .PHONY: serve
 serve: build
 serve:
-	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=${PREVIEW_MODE}
+	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG)
 
 .PHONY: run
 run: serve

--- a/src/content.rs
+++ b/src/content.rs
@@ -65,7 +65,7 @@ pub fn all_pages(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<BTreeMa
     let mut contents = BTreeMap::new();
     for f in files {
         let raw_data = std::fs::read_to_string(&f)?;
-        let content: Content = raw_data.parse()?;
+        let content: Content = raw_data.parse().map_err(|e|anyhow::anyhow!("File {:?}: {}", &f, e))?;
         if show_unpublished || content.published {
             contents.insert(f.to_string_lossy().to_string(), content.into());
         }
@@ -161,7 +161,7 @@ impl FromStr for Content {
         let (toml_text, body) = full_document
             .split_once(DOC_SEPERATOR)
             .unwrap_or(("title = 'Untitled'", &full_document));
-        let head: Head = toml::from_str(toml_text)?;
+        let head: Head = toml::from_str(toml_text).map_err(|e| anyhow::anyhow!("TOML parsing error: {}", e))?;
 
         Ok(Content::new(head, body.to_owned()))
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -113,7 +113,8 @@ impl<'a> Renderer<'a> {
             if let Some(fn_name) = script.file_stem() {
                 eprintln!("scripts: registering {}", fn_name.to_str().unwrap_or("unknown"));
                 self.handlebars
-                    .register_script_helper_file(&fn_name.to_string_lossy(), &script)?;
+                    .register_script_helper_file(&fn_name.to_string_lossy(), &script)
+                    .map_err(|e|anyhow::anyhow!("Script {:?}: {}", &script, e))?;
             }
         }
 
@@ -153,7 +154,8 @@ impl<'a> Renderer<'a> {
             // Copy the WASI env into the env template var.
             env: std::env::vars().collect(),
         };
-        let out = self.handlebars.render(&tpl, &ctx)?;
+        let out = self.handlebars.render(&tpl, &ctx)
+            .map_err(|e|anyhow::anyhow!("Template '{}': {}", &tpl, e))?;
         Ok(out)
     }
 


### PR DESCRIPTION
This adds the following:

- Better error messages for template parser errors, TOML header parse errors, YAML parse errors, and Rhai script errors
- A `SHOW_DEBUG` env var that sends debug data to the browser when set to `1`
- `Makefile` support for `SHOW_DEBUG`

For example, old error message:
```
Internal Server Error: newline in string found at line 2 column 72
```

New error message:
```
Internal Server Error: Rendering "/content/index.md": Parsing "/content/blog/2021-09-31-goals-of-bartholomew.md": TOML parsing error: newline in string found at line 2 column 72
```

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>