### PR TITLE
Minify the HTML output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "handlebars",
+ "minify",
  "pulldown-cmark",
  "serde",
  "serde_json",
@@ -189,6 +190,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minify"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93bacfc6ce0cf3e41da4d9415904090e1f7ca8d105c1396907f78d8fee42635"
 
 [[package]]
 name = "num-integer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
 chrono = {version = "0.4", features = ["serde"]}
+minify = "1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,10 @@ fn exec() -> anyhow::Result<()> {
 
             let content_type = doc.head.content_type.clone().unwrap_or_else(||DEFAULT_CONTENT_TYPE.to_owned());
 
-            let data = engine.render_template(doc, config).map_err(|e| anyhow::anyhow!("Rendering {:?}: {}", &content_path, e))?;
+            let mut data = engine.render_template(doc, config).map_err(|e| anyhow::anyhow!("Rendering {:?}: {}", &content_path, e))?;
+            if content_type.starts_with("text/html") {
+                data = minify::html::minify(&data);
+            }
             html_ok(path_info, data, content_type);
             Ok(())
         }


### PR DESCRIPTION
This minifies the HTML output from Bartholomew.

Per the TIGM site, we should be minifying the HTML output of our site.

https://thisisgoodmarketing.com/courses/content-engine/setting-up/cms

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>