### PR TITLE
Cache page metadata on first request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /modules/*.wasm
 /logs
+/config/_cache.json

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ WAGI ?= wagi
 # If PREVIEW_MODE is on then unpublished content will be displayed.
 PREVIEW_MODE ?= 0
 SHOW_DEBUG ?= 1
+DISABLE_CACHE ?= 1
 
 .PHONY: build
 build:
@@ -12,7 +13,8 @@ build:
 .PHONY: serve
 serve: build
 serve:
-	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG)
+	rm -rf config/_cache.json
+	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG) -e DISABLE_CACHE=$(DISABLE_CACHE)
 
 .PHONY: run
 run: serve

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ build:
 .PHONY: serve
 serve: build
 serve:
-	rm -rf config/_cache.json
 	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG) -e DISABLE_CACHE=$(DISABLE_CACHE)
 
 .PHONY: run
@@ -23,3 +22,7 @@ run: serve
 .PHONY: date
 date:
 	date -u +"%Y-%m-%dT%H:%M:%SZ"
+
+.PHONY: clean
+clean:
+	rm -rf config/_cache.json

--- a/README.md
+++ b/README.md
@@ -190,3 +190,20 @@ have access to the Markdown version of the document.
 
 To print the HTML body without having the output escaped, use `{{{ page.body }}}` (note the
 triple curly braces).
+
+### The Page Cache
+
+Unless the environment variable `-e DISABLE_CACHE=1` is set, the first load of a site will create a cache
+of page metadata in `config/_cache.json`. This is an optimization to reduce the number of file IO operations
+Bartholomew needs to make.
+
+If you are actively developing content, we suggest setting `DISABLE_CACHE=1`. By default, the `Makefile`'s `make serve`
+target disables the cache, as `make serve` is assumed to be used only for developers.
+
+### Debug Mode
+
+By default, Bartholomew does not send error messages to the browser.
+This can make it hard to debug templates and Rhai scripts.
+To send error messages to the browser, set `-e DEBUG_MODE=1`.
+
+The `Makefile`'s `make serve` command defaults to enabling debug mode, as `make serve` is assumed to be used only for development.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,6 @@ target disables the cache, as `make serve` is assumed to be used only for develo
 
 By default, Bartholomew does not send error messages to the browser.
 This can make it hard to debug templates and Rhai scripts.
-To send error messages to the browser, set `-e DEBUG_MODE=1`.
+To send error messages to the browser, set `-e SHOW_DEBUG=1`.
 
 The `Makefile`'s `make serve` command defaults to enabling debug mode, as `make serve` is assumed to be used only for development.

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -140,6 +140,7 @@ Note that you can create custom template helpers using [Rhai scripts](/docs/rhai
 
 The following helper functions are provided with Bartholomew
 
+- `load_page STRING`: Load HTML content for a given URI. For example `load_page "foo"` will load the page at `/content/foo.md` and return the HTML body.
 - `upper STRING`: converts the given string to uppercase
 - `lower STRING`: converts the given string to lowercase
 - `date_format STRING DATE`: Formats a date using the given string. `date "%Y" page.head.date`. Use [strftime format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html#specifiers).

--- a/src/content.rs
+++ b/src/content.rs
@@ -11,6 +11,9 @@ use crate::template::PageValues;
 
 const DOC_SEPERATOR: &str = "\n---\n";
 
+// TODO: This should probably be configurable.
+const CACHE_FILE: &str = "/config/_cache.json";
+
 /// Head contains the front matter for a document
 #[derive(Deserialize, Serialize)]
 pub struct Head {
@@ -60,16 +63,39 @@ pub fn content_path(content_dir: PathBuf, path_info: &str) -> PathBuf {
 /// 
 /// If show_unpublished is `true`, this will include pages that Bartholomew has determined are
 /// unpublished.
-pub fn all_pages(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<BTreeMap<String, PageValues>> {
+pub fn all_pages(dir: PathBuf, show_unpublished: bool, skip_cache: bool) -> anyhow::Result<BTreeMap<String, PageValues>> {
+
+    if skip_cache {
+        return all_pages_load(dir, show_unpublished);
+    }
+
+    // Try loading the cached object:
+    let cache = PathBuf::from(CACHE_FILE);
+    match std::fs::read_to_string(&cache) {
+        Ok(data) => {
+            // We have the whole site here.
+            serde_json::from_str(&data).map_err(|e| anyhow::anyhow!("Failed to parse page cache TOML: {}", e))
+        },
+        Err(_) => {
+            let contents = all_pages_load(dir, show_unpublished)?;
+            // Serialize the files back out to disk for subsequent requests.
+            let cache_data = serde_json::to_string(&contents)?;
+            std::fs::write(&cache, cache_data)?;
+            Ok(contents)
+        }
+    }
+}
+
+fn all_pages_load(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<BTreeMap<String, PageValues>> {
     let files = all_files(dir)?;
     let mut contents = BTreeMap::new();
     for f in files {
-        let raw_data = std::fs::read_to_string(&f)?;
-        let content: Content = raw_data.parse().map_err(|e|anyhow::anyhow!("File {:?}: {}", &f, e))?;
+        let content = Content::header_from_path(f.clone()).map_err(|e|anyhow::anyhow!("File {:?}: {}", &f, e))?;
         if show_unpublished || content.published {
             contents.insert(f.to_string_lossy().to_string(), content.into());
         }
     }
+    // Serialize the files back out to disk for subsequent requests.
     Ok(contents)
 }
 
@@ -108,7 +134,7 @@ pub struct Content {
     /// The front matter for this content.
     pub head: Head,
     /// The unparsed Markdown for this content.
-    pub body: String,
+    body: Option<String>,
     /// The published state.
     /// 
     /// Published state is determined when a new Content is created.
@@ -122,6 +148,8 @@ pub struct Content {
     /// 
     /// Practically speaking, what this means is that content is published by default.
     pub published: bool,
+    /// Path to the source file
+    pub path: PathBuf,
 }
 
 impl Content {
@@ -131,7 +159,7 @@ impl Content {
     /// This determines published state based on the head.
     ///
     /// The environment is copied from the system environment. This is safe when executed inside of Wagi or a WASI runtime.
-    pub fn new(head: Head, body: String) -> Self {
+    pub fn new(head: Head, body: String, path: PathBuf) -> Self {
         let pdate = head.date.clone();
 
         // If explicitly published in the front matter, mark it published
@@ -139,30 +167,55 @@ impl Content {
         // Else if no date is set, mark it published
         let published = head.published.unwrap_or_else(|| pdate.map(|d|d <= Utc::now()).unwrap_or(true));
 
-        Content { head, body, published }
+        Content { head, body: Some(body), published, path }
     }
 
     /// Render the body using a Markdown renderer
-    pub fn render_markdown(&self) -> String {
+    pub fn render_markdown(&self) -> anyhow::Result<String> {
         let mut buf = String::new();
 
         // Might as well turn on all the lights on the Christmas tree
         let opt = markdown::Options::all();
-        let parser = markdown::Parser::new_ext(&self.body, opt);
+        let body = self.body()?;
+        let parser = markdown::Parser::new_ext(body.as_str(), opt);
         markdown::html::push_html(&mut buf, parser);
 
-        buf
+        Ok(buf)
     }
-}
 
-impl FromStr for Content {
-    type Err = anyhow::Error;
-    fn from_str(full_document: &str) -> Result<Self, Self::Err> {
+    /// Create a Content without a body.
+    pub fn header_from_path(path: PathBuf) -> anyhow::Result<Self> {
+        let full_document = std::fs::read_to_string(&path)?;
+        let (toml_text, _body) = full_document
+            .split_once(DOC_SEPERATOR)
+            .unwrap_or(("title = 'Untitled'", &full_document));
+        let head: Head = toml::from_str(toml_text).map_err(|e| anyhow::anyhow!("TOML parsing error: {}", e))?;
+        Ok(Self::new(head, "".to_owned(), path))
+    }
+
+    pub fn from_path(path: PathBuf) -> anyhow::Result<Self> {
+        let full_document = std::fs::read_to_string(&path)?;
         let (toml_text, body) = full_document
             .split_once(DOC_SEPERATOR)
             .unwrap_or(("title = 'Untitled'", &full_document));
         let head: Head = toml::from_str(toml_text).map_err(|e| anyhow::anyhow!("TOML parsing error: {}", e))?;
 
-        Ok(Content::new(head, body.to_owned()))
+        Ok(Content::new(head, body.to_owned(), path.to_owned()))
+    }
+
+    pub fn body(&self) -> anyhow::Result<String> {
+        match self.body.clone() {
+            Some(data) => Ok(data),
+            None => {
+                // Reload the content
+                let full_document = std::fs::read_to_string(self.path.clone())?;
+                // Parse the content
+                let (_toml_text, body) = full_document
+                    .split_once(DOC_SEPERATOR)
+                    .unwrap_or(("title = 'Untitled'", &full_document));
+                // Return the body
+                Ok(body.to_owned())
+            }
+        }
     }
 }

--- a/templates/blog.hbs
+++ b/templates/blog.hbs
@@ -11,7 +11,7 @@
                     href="{{page.head.extra.author_page}}">{{page.head.extra.author}}</a>{{/if}}
             </p>
             {{! Since this is HTML, we use the triple-curly }}
-            {{{page.body}}}
+            {{{load_page this.uri}}}
             <p><a href="{{this.uri}}">View the Post</a></p>
     </article>
     {{/each}}

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -29,7 +29,7 @@ This content is unpublished.
             <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
                 <h5 class="card-title">{{this.page.head.title}}</h5>
-                <p class="card-text">{{{page.body}}}</p>
+                <p class="card-text">{{{load_page "features/wasm"}}}</p>
             </div>
         </div>
         {{/with}}
@@ -38,7 +38,7 @@ This content is unpublished.
             <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
                 <h5 class="card-title">{{this.page.head.title}}</h5>
-                <p class="card-text">{{{page.body}}}</p>
+                <p class="card-text">{{{load_page "features/wagi"}}}</p>
             </div>
         </div>
         {{/with}}
@@ -47,7 +47,7 @@ This content is unpublished.
             <img src="{{page.head.extra.image}}" class="card-img-top" alt="{{page.head.title}}">
             <div class="card-body">
                 <h5 class="card-title">{{this.page.head.title}}</h5>
-                <p class="card-text">{{{page.body}}}</p>
+                <p class="card-text">{{{load_page "features/kiss"}}}</p>
             </div>
         </div>
         {{/with}}


### PR DESCRIPTION
During testing, I realized that every page on the site was being reloaded from disk on every single page request. This PR caches page metadata so that navigation, listings, and so on can be generated from a cache without doing so much file IO

This PR adds page caching:

- A page cache is written to `config/_cache.json` that has the page metadata cached. Because `config/` is not accessible to template file loaders, this is a safe place to put a cache.
- The cache is generated on startup (once).
- The new `load_page` template function loads a page body only when needed
- Wagi can disable caching via the `-e DISABLE_CACHE=1` env var.
- The Makefile's `make serve`, which is a developer target, disables page caching for development
- Core templates have been updated to use `load_page` where necessary

In the future, we might want to make the page cache expire periodically. Right now, given the way Hippo deploys Wagi, though, it is not possible to change page content during a Wagi process's lifetime. So a static cache is very efficient.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>