### PR TITLE
Run wasm-opt on bartholomew.wasm during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHOW_DEBUG ?= 1
 .PHONY: build
 build:
 	cargo build --target wasm32-wasi --release
+	wasm-opt -O target/wasm32-wasi/release/bartholomew.wasm -o target/wasm32-wasi/release/bartholomew.wasm
 	# Keep an eye on the binary size. We want it under 5M
 	@ls -lah target/wasm32-wasi/release/*.wasm
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Currently, the best way to get Bartholomew is to fetch this directory. To build
 Bartholomew from source, just run `make build`, which basically does a
 `cargo build --target wasm32-wasi --release`.
 
+> `make build` also runs `wasm-opt`, which is part of the [Binaryen](https://webassembly.github.io/binaryen/) project.
+> This reduces the size of the WebAssembly module by optimizing the bytecode.
+
 You can also use the pre-built `batholomew.wasm` or the versioned bindles.
 
 To run Bartholomew, you will need a Wagi-capable runtime.


### PR DESCRIPTION
This runs `wasm-opt` from [Binaryen](https://webassembly.github.io/binaryen/) on the `bartholomew.wasm` file right after compiling in `make build`.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>