### PR TITLE
Add BASE_URL env var to override site.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ WAGI ?= wagi
 # If PREVIEW_MODE is on then unpublished content will be displayed.
 PREVIEW_MODE ?= 0
 SHOW_DEBUG ?= 1
+BASE_URL ?= http://localhost:3000
 
 .PHONY: build
 build:
@@ -12,7 +13,7 @@ build:
 .PHONY: serve
 serve: build
 serve:
-	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG)
+	$(WAGI) -c ./modules.toml --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG) -e BASE_URL=$(BASE_URL)
 
 .PHONY: run
 run: serve

--- a/content/docs/config.md
+++ b/content/docs/config.md
@@ -27,7 +27,7 @@ It has a few pre-defined fields:
 
 - title: the title of your website
 - logo: a URL or static path to your logo
-- base_url: a base URL that templates can use to construct full URLs to content
+- base_url: a base URL that templates can use to construct full URLs to content. This can be overridden by setting the `-e BASE_URL="https://example.com"` environment variable for Wagi.
 - about: a brief description of the site
 
 You can define your own fields in the `[extra]` section. Anything in `[extra]` is not

--- a/content/docs/handlebars.md
+++ b/content/docs/handlebars.md
@@ -65,6 +65,7 @@ In addition to the `page` object, there is also a `site` object:
     info: {
         title: "site title"
         about: "Site about information"
+        base_url: "http://localhost:3000"
         extra: {
             copyright: "site-wide copyring (this is not required, since it's in extra)"
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,13 @@ fn exec() -> anyhow::Result<()> {
 
     // Load the site config
     let raw_config = std::fs::read(CONFIG_FILE)?;
-    let config: template::SiteInfo = toml::from_slice(&raw_config)?;
+    let mut config: template::SiteInfo = toml::from_slice(&raw_config)?;
+
+    let base_url = std::env::var("BASE_URL");
+    if base_url.is_ok() {
+        config.base_url = Some(base_url.unwrap());
+    }
+    eprintln!("Base URL: {:?}", &config.base_url);
 
     
     let mut engine = template::Renderer::new(

--- a/src/template.rs
+++ b/src/template.rs
@@ -15,11 +15,11 @@ const DEFAULT_TEMPLATE: &str = "main";
 /// Describe the site itself
 #[derive(Serialize, Deserialize)]
 pub struct SiteInfo {
-    title: String,
-    logo: Option<String>,
-    base_url: Option<String>,
-    about: Option<String>,
-    extra: BTreeMap<String, String>,
+    pub title: String,
+    pub logo: Option<String>,
+    pub base_url: Option<String>,
+    pub about: Option<String>,
+    pub extra: BTreeMap<String, String>,
 }
 
 /// Context for a template render.

--- a/templates/navbar.hbs
+++ b/templates/navbar.hbs
@@ -8,26 +8,26 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                    <a class="nav-link" href="/index">Home</a>
+                    <a class="nav-link" href="{{site.info.base_url}}/index">Home</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/blog">Blog</a>
+                    <a class="nav-link" href="{{site.info.base_url}}/blog">Blog</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="/docs/index" id="navbarDropdown" role="button"
+                    <a class="nav-link dropdown-toggle" href="{{site.base_url}}/docs/index" id="navbarDropdown" role="button"
                         data-bs-toggle="dropdown" aria-expanded="false">
                         Documentation
                     </a>
                     <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-                        <li><a class="dropdown-item" href="/docs/config">Editing the Config File</a></li>
-                        <li><a class="dropdown-item" href="/docs/markdown">Writing Markdown</a></li>
-                        <li><a class="dropdown-item" href="/docs/handlebars">Templating with Handlebars</a></li>
-                        <li><a class="dropdown-item" href="/docs/rhai">Scripting with Rhai</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/docs/config">Editing the Config File</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/docs/markdown">Writing Markdown</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/docs/handlebars">Templating with Handlebars</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/docs/rhai">Scripting with Rhai</a></li>
                         <li>
                             <hr class="dropdown-divider">
                         </li>
-                        <li><a class="dropdown-item" href="/helpers_example">Example of Helpers</a></li>
-                        <li><a class="dropdown-item" href="/markdown">Markdown Example</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/helpers_example">Example of Helpers</a></li>
+                        <li><a class="dropdown-item" href="{{site.info.base_url}}/markdown">Markdown Example</a></li>
                     </ul>
                 </li>
                 <li class="nav-item">


### PR DESCRIPTION
This allows you to set: `-e BASE_URL="https://example.com"` as an environment variable and have that override the configuration in `site.toml`. As @flynnduism noted, this ability to override is common in other CMS systems.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>