### PR TITLE
Add support for custom status and redirect

### DIFF
--- a/content/docs/markdown.md
+++ b/content/docs/markdown.md
@@ -54,6 +54,8 @@ The following fields are defined for Bartholomew:
 - `tags`: A list of tags. The tags should be ranked most- to least-relevant. OPTIONAL and defaults to an empty list.
 - `content_type`: A media type for the document. For example, if you are generating XML, use `text/xml`. The default is HTML. OPTIONAL and should rarely be used.
     - NOTE: `content_type` has no impact on the formatting. That is, Markdown will still be rendered to HTML.
+- `status`: (EXPERT) Status code and message for HTTP. E.g. "302 Found"
+- `redirect`: (EXPERT) Send a redirect to the given fully qualified URL. Default redirect type is `301 Moved Permanently`. Use `status` to set another redirect type. When this is set, no body is sent to the client.
 - `[extra]`: The section marker that indicates that all content after it is user-defined.
     - Fields under extra MUST be in the form `name = "value"`. All values must be strings.
     - once the `[extra]` section is declared, you cannot declare top-level fields anymore.

--- a/content/redirect_example.md
+++ b/content/redirect_example.md
@@ -1,0 +1,10 @@
+title = "Example of a redirect"
+date = "2022-02-11T22:29:17Z"
+
+# This will return a 302 Found redirect 
+# If status is omitted, this will return a 301 Moved Permanently status
+status = "302 Found"
+# redirect = "https://github.com/fermyon/bartholomew"
+redirect = "http://localhost:3000/"
+---
+

--- a/content/redirect_example.md
+++ b/content/redirect_example.md
@@ -4,7 +4,6 @@ date = "2022-02-11T22:29:17Z"
 # This will return a 302 Found redirect 
 # If status is omitted, this will return a 301 Moved Permanently status
 status = "302 Found"
-# redirect = "https://github.com/fermyon/bartholomew"
 redirect = "http://localhost:3000/"
 ---
 

--- a/src/content.rs
+++ b/src/content.rs
@@ -45,6 +45,19 @@ pub struct Head {
     /// 
     /// This may result in HTTP headers being altered.
     pub content_type: Option<String>,
+
+    /// An optional status line
+    /// 
+    /// This should only ever be set if the status code is _not_ 200.
+    /// It can be used for redirects (3xx), intentional error messages (4xx, 5xx) or
+    /// for specialized responses (2xx). It should not be used for 1xx codes unless
+    /// you really know what you are doing.
+    pub status: Option<String>,
+
+    /// A fully qualified URL to another resources.
+    /// 
+    /// If no status code is set, this will set the status code to 301 Moved Permanently
+    pub redirect: Option<String>,
 }
 
 /// Given a PATH_INFO variable, transform it into a path for a specific markdown file

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ const DEFAULT_INDEX: &str = "/index";
 const DEFAULT_CONTENT_TYPE: &str = "text/html; charset=utf-8";
 
 const DEFAULT_500_ERR: &str = "An internal error occurred";
+const DEFAULT_3XX_CODE: &str = "301 Moved Permanently";
 
 fn main() {
     let debug_mode = match std::env::var("SHOW_DEBUG") {
@@ -99,13 +100,25 @@ fn exec() -> anyhow::Result<()> {
 
             let status_opt = doc.head.status.clone();
             let loc_opt = doc.head.redirect.clone();
-            let content_type = doc.head.content_type.clone().unwrap_or_else(||DEFAULT_CONTENT_TYPE.to_owned());
 
-            let mut data = engine.render_template(doc, config).map_err(|e| anyhow::anyhow!("Rendering {:?}: {}", &content_path, e))?;
-            if content_type.starts_with("text/html") {
-                data = minify::html::minify(&data);
+            match loc_opt {
+                Some(location) => {
+                    let status = status_opt.unwrap_or_else(|| DEFAULT_3XX_CODE.to_owned());
+                    send_redirect(path_info, location, status);
+                }
+                None => {
+                    let content_type = doc.head.content_type.clone().unwrap_or_else(||DEFAULT_CONTENT_TYPE.to_owned());
+
+                    let mut data = engine.render_template(doc, config).map_err(|e| anyhow::anyhow!("Rendering {:?}: {}", &content_path, e))?;
+                    if content_type.starts_with("text/html") {
+                        data = minify::html::minify(&data);
+                    }
+                    send_result(path_info, data, content_type, status_opt);
+
+                }
             }
-            send_result(path_info, data, content_type, status_opt, loc_opt);
+
+            
             Ok(())
         }
         Err(_) => {
@@ -131,22 +144,18 @@ fn internal_server_error(body: String) {
 }
 
 // This function is getting a little gnarly.
-fn send_result(route: String, body: String, content_type: String, status_opt: Option<String>, location_opt: Option<String>) {
+fn send_result(route: String, body: String, content_type: String, status_opt: Option<String>) {
     eprintln!("responded: {}", route);
 
-    match location_opt {
-        Some(loc) => {
-            let status = status_opt.unwrap_or_else(|| "301 Moved Permanently".to_owned());
-            println!("Status: {}\nLocation: {}\n", status, loc)
-        },
-        None => {
-            // Intentionally do not override the Wagi default behavior with a default Bartholomew message.
-            if let Some(status) = status_opt {
-                println!("Status: {}", status);
-            }
-            println!("Content-Type: {}\n", content_type);
-            println!("{}", body);
-        }
+    // Intentionally do not override the Wagi default behavior with a default Bartholomew message.
+    if let Some(status) = status_opt {
+        println!("Status: {}", status);
     }
-    
+    println!("Content-Type: {}\n", content_type);
+    println!("{}", body);
+}
+
+fn send_redirect(route: String, location: String, status: String) {
+    eprintln!("redirected {} to {} (Code: {})", route, &location, &status);
+    println!("Status: {}\nLocation: {}\n", status, location)
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -273,6 +273,8 @@ pub fn error_values(title: &str, msg: &str) -> PageValues {
             published: None,
             tags: vec![],
             content_type: None,
+            status: None,
+            redirect: None,
         },
         body: msg.to_string(),
         published: true,


### PR DESCRIPTION
Originally I had planned on making redirect support a separate module. But this has turned out to be clumsy and intrusive. So instead, I have added support for redirecting to Bartholomew.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>