### PR TITLE
feat: add bart CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -32,8 +52,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "bartholomew"
+name = "bart"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bartholomew",
+ "chrono",
+ "colorful",
+ "structopt",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "bartholomew"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -87,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +147,27 @@ dependencies = [
  "time",
  "winapi",
 ]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "colorful"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bca1619ff57dd7a56b58a8e25ef4199f123e78e503fe1653410350a1b98ae65"
 
 [[package]]
 name = "crc32fast"
@@ -191,6 +254,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,10 +287,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "libc"
-version = "0.2.101"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -225,6 +321,15 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -249,6 +354,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +424,29 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "pest"
@@ -323,10 +492,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -394,6 +613,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "rhai"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +685,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -478,6 +736,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,10 +769,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -510,6 +826,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,12 +854,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+dependencies = [
+ "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -550,10 +1002,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -608,3 +1084,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "bartholomew"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 
 [dependencies]
-anyhow = "1.0.43"
+anyhow = "1.0"
+chrono = {version = "0.4", features = ["serde"]}
+flate2 = "1.0"
 handlebars = {version = "4.1", features = ["dir_source", "script_helper"]}
+handlebars_sprig = { version = "0.2.0" }
+minify = "1.2"
 pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"
-chrono = {version = "0.4", features = ["serde"]}
-minify = "1.2"
-handlebars_sprig = { version = "0.2.0" }
-flate2 = "1.0.22"
+
+[workspace]
+members = ["bart"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,16 @@ build:
 	# Keep an eye on the binary size. We want it under 5M
 	@ls -lah target/wasm32-wasi/release/*.wasm
 
+.PHONY: bart
+bart:
+	cargo build --release --manifest-path=bart/Cargo.toml
+
+.PHONY: test
+test:
+	RUST_LOG=$(LOG_LEVEL) cargo test --all -- --nocapture
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo fmt --all -- --check
+
 .PHONY: serve
 serve: build
 serve:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out [the docs](/content/docs)
 
 The easiest way to start is to get the [Bartholomew site template](https://github.com/fermyon/bartholomew-site-template) and then download the [latest release of Bartholomew](https://github.com/fermyon/bartholomew/releases).
 
-### Building from Source 
+### Building from Source
 
 To build Bartholomew from source, just run `make build`, which basically does a
 `cargo build --target wasm32-wasi --release`.
@@ -176,7 +176,7 @@ Bartholomew uses a [version of the Handlebars template language](https://crates.
 The template syntax is describe in the [Handlebars documentation](https://handlebarsjs.com/).
 
 Every file in the `templates/` directory will be compiled to a template. The file is then
-accessible by its relative name, minus the extension. For example. `templates/main.hbs` 
+accessible by its relative name, minus the extension. For example. `templates/main.hbs`
 will be accessible as `main`.
 
 Note that Bartholomew _expects_ to find a template named `main`. This template is used as
@@ -194,3 +194,19 @@ have access to the Markdown version of the document.
 
 To print the HTML body without having the output escaped, use `{{{ page.body }}}` (note the
 triple curly braces).
+
+## The Bartholomew CLI
+
+This is a very early work in progress implementation for a CLI that simplifies
+working with Bartholomew applications:
+
+```
+ ➜ bart calendar ./content
+Wed, Dec 22, 2021 - 'Documentation' index.md
+Thu, Dec 23, 2021 - 'First Post!' 2021-12-23-first-post.md
+Thu, Dec 23, 2021 - 'What Is Markdown?' 2021-12-23-what-is-markdown.md
+Thu, Dec 23, 2021 - 'Markdown examples' markdown.md
+
+ ➜ bart new post content/blog --author "Radu Matei" --template abc --title "Writing a new post using Bart"
+Wrote new post in file content/blog/untitled.md
+```

--- a/bart/Cargo.toml
+++ b/bart/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bart"
+version = "0.1.0"
+edition = "2021"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+
+[dependencies]
+anyhow = "1.0.42"
+bartholomew = { path = "../" }
+chrono = { version = "0.4.19", features = ["serde"] }
+colorful = "0.2.1"
+structopt = "0.3.22"
+tokio = { version = "1.8.1", features = [ "full" ] }
+toml = "0.5.8"
+tracing = { version = "0.1.26", features = [ "log" ] }
+tracing-futures = "0.2.5"
+tracing-subscriber = { version = "0.2.19", features = [ "env-filter" ] }

--- a/bart/src/commands/calendar.rs
+++ b/bart/src/commands/calendar.rs
@@ -1,0 +1,87 @@
+use anyhow::{anyhow, Result};
+use bartholomew::content::{self, Head};
+use chrono::{Duration, Utc};
+use colorful::{Color, Colorful};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+
+pub const DOC_SEPARATOR: &str = "\n---\n";
+const DATE_FORMAT: &str = "%a, %b %d, %Y";
+const MAX_DAYS: i64 = 7;
+
+/// Print the content calendar for a Bartholomew website.
+#[derive(StructOpt, Debug)]
+#[structopt(alias = "cal")]
+pub struct CalendarCommand {
+    /// The path to the Bartholomew content directory.
+    #[structopt()]
+    pub paths: Vec<PathBuf>,
+}
+
+impl CalendarCommand {
+    /// Run the bart calendar command.
+    pub async fn run(self) -> Result<()> {
+        let now = Utc::now();
+
+        // Print a content calendar for every given director.
+        for dir in self.paths {
+            // Walk the content directory.
+            let files = content::all_files(dir)?;
+            let mut posts = vec![];
+            for f in files {
+                let raw_data = std::fs::read_to_string(&f)
+                    .map_err(|e| anyhow::anyhow!("File is not string data: {:?}: {}", &f, e))?;
+
+                posts.push(from_file(raw_data, &f)?);
+            }
+
+            posts.sort_by(|a, b| a.head.date.partial_cmp(&b.head.date).unwrap());
+
+            let mut last = Utc::now();
+            for post in posts {
+                let date = post.head.date.unwrap_or_else(Utc::now);
+                let c = if date < now {
+                    Color::Green
+                } else {
+                    Color::Yellow
+                };
+
+                let mut dc = "".to_owned();
+
+                let dur = date.signed_duration_since(last);
+                if dur > Duration::days(MAX_DAYS) {
+                    dc = format!("({})", dur.num_days())
+                        .color(Color::Red)
+                        .to_string();
+                }
+
+                let filename = post.path.file_name().unwrap().to_string_lossy();
+                println!(
+                    "{} - '{}' {} {}",
+                    date.format(DATE_FORMAT),
+                    post.head.title.color(c),
+                    filename,
+                    dc
+                );
+                last = date;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn from_file(doc: String, path: &Path) -> Result<Metadata> {
+    let (toml_text, _) = doc
+        .split_once(DOC_SEPARATOR)
+        .unwrap_or(("title = 'Untitled'", &doc));
+    let head: Head = toml::from_str(toml_text).map_err(|e| anyhow!("TOML parsing error: {}", e))?;
+    let path = path.into();
+
+    Ok(Metadata { path, head })
+}
+
+struct Metadata {
+    path: PathBuf,
+    head: Head,
+}

--- a/bart/src/commands/mod.rs
+++ b/bart/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod calendar;
+pub mod new;

--- a/bart/src/commands/new.rs
+++ b/bart/src/commands/new.rs
@@ -1,0 +1,104 @@
+use crate::commands::calendar::DOC_SEPARATOR;
+use anyhow::Result;
+use bartholomew::content::{Content, Head};
+use chrono::Utc;
+use std::{collections::HashMap, path::PathBuf};
+use structopt::StructOpt;
+use tokio::{fs::File, io::AsyncWriteExt};
+
+/// Create a new page or website from a template.
+#[derive(StructOpt, Debug)]
+pub enum NewCommand {
+    Post(NewPostCommand),
+}
+
+impl NewCommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            NewCommand::Post(cmd) => cmd.run().await,
+        }
+    }
+}
+
+/// Create a new post.
+#[derive(StructOpt, Debug)]
+pub struct NewPostCommand {
+    /// Path to the directory where to create the new post.
+    pub dir: PathBuf,
+
+    /// Name of the file.
+    #[structopt(default_value = "untitled.md")]
+    pub file: String,
+    /// Title for the post.
+    #[structopt(long = "title", default_value = "Untitled")]
+    pub title: String,
+    /// Description for the post.
+    #[structopt(long = "description")]
+    pub description: Option<String>,
+    /// Template for the post.
+    #[structopt(long = "template", default_value = "blog")]
+    pub template: String,
+    /// Type of the post.
+    #[structopt(long = "type", default_value = "post")]
+    pub post_type: String,
+    /// Author of the post.
+    #[structopt(long = "author", default_value = "John Doe")]
+    pub author: String,
+}
+
+impl NewPostCommand {
+    pub async fn run(self) -> Result<()> {
+        let template = Some(self.template);
+        let title = self.title;
+        let date = Some(Utc::now());
+
+        let mut extra = HashMap::new();
+        extra.insert("author".to_string(), self.author);
+        extra.insert("type".to_string(), self.post_type);
+
+        let description = self.description;
+        let published = Some(true);
+
+        let extra = Some(extra);
+        let head = Head {
+            title,
+            date,
+            description,
+            template,
+            extra,
+            published,
+            ..Default::default()
+        };
+
+        let body = r#"
+Begin with intro paragraph
+
+<!-- Ideally, for SEO there should be an image after the first paragraph or two -->
+
+## Headers Should Be Second-level, Not First
+"#
+        .to_string();
+
+        let content = Content {
+            head,
+            body,
+            published: true,
+        };
+
+        let content = serialize_content(&content)?;
+        let path = self.dir.join(&self.file);
+        let mut file = File::create(&path).await?;
+        file.write_all(content.as_bytes()).await?;
+
+        println!("Wrote new post in file {}", path.display());
+
+        Ok(())
+    }
+}
+
+fn serialize_content(content: &Content) -> Result<String> {
+    let mut res = toml::to_string(&content.head)?;
+    res.push_str(DOC_SEPARATOR);
+    res.push_str(&content.body);
+    Ok(res)
+}

--- a/bart/src/main.rs
+++ b/bart/src/main.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use commands::{calendar::CalendarCommand, new::NewCommand};
+use structopt::{clap::AppSettings, StructOpt};
+
+mod commands;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    BartApp::from_args().run().await
+}
+
+/// The Bartholomew CLI
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "bart",
+    version = env!("CARGO_PKG_VERSION"),
+    global_settings = &[
+        AppSettings::VersionlessSubcommands,
+        AppSettings::ColoredHelp
+    ])]
+enum BartApp {
+    Calendar(CalendarCommand),
+    New(NewCommand),
+}
+
+impl BartApp {
+    /// The main entry point to Bart.
+    pub async fn run(self) -> Result<()> {
+        match self {
+            BartApp::Calendar(cmd) => cmd.run().await,
+            BartApp::New(cmd) => cmd.run().await,
+        }
+    }
+}

--- a/src/content.rs
+++ b/src/content.rs
@@ -4,15 +4,15 @@ use std::fs::{read_dir, DirEntry};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use chrono::{DateTime, Utc};
 use pulldown_cmark as markdown;
-use chrono::{Utc, DateTime};
 
 use crate::template::PageValues;
 
-const DOC_SEPERATOR: &str = "\n---\n";
+const DOC_SEPARATOR: &str = "\n---\n";
 
 /// Head contains the front matter for a document
-#[derive(Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct Head {
     /// The title of the document
     pub title: String,
@@ -22,42 +22,38 @@ pub struct Head {
     pub description: Option<String>,
     /// The template to be used. If None, the `main` template is used.
     pub template: Option<String>,
-    /// A map of string/string pairs that are user-customizable.
-    pub extra: Option<HashMap<String, String>>,
     /// An explicit flag to control publish state.
-    /// 
+    ///
     /// If this is set, it will explicitly set the publish state of a piece of content.
     /// If this is None, then the publish state will be derived from things like date.
     pub published: Option<bool>,
-
     /// Article tags
-    /// 
+    ///
     /// In the template language, having an Option<Vec<>> can get really confusing,
     /// so the deserializer just creates an empty vec if not present in the source
     /// doc.
     #[serde(default)]
     pub tags: Vec<String>,
-
     /// Content type overrides the MIME/media type of the body.
-    /// 
+    ///
     /// This should only be used if the referenced `template` will generate a type other
     /// than HTML. For examle, a site map may use text/xml and a robots.txt may use text/plain.
-    /// 
+    ///
     /// This may result in HTTP headers being altered.
     pub content_type: Option<String>,
-
     /// An optional status line
-    /// 
+    ///
     /// This should only ever be set if the status code is _not_ 200.
     /// It can be used for redirects (3xx), intentional error messages (4xx, 5xx) or
     /// for specialized responses (2xx). It should not be used for 1xx codes unless
     /// you really know what you are doing.
     pub status: Option<String>,
-
     /// A fully qualified URL to another resources.
-    /// 
+    ///
     /// If no status code is set, this will set the status code to 301 Moved Permanently
     pub redirect: Option<String>,
+    /// A map of string/string pairs that are user-customizable.
+    pub extra: Option<HashMap<String, String>>,
 }
 
 /// Given a PATH_INFO variable, transform it into a path for a specific markdown file
@@ -70,29 +66,36 @@ pub fn content_path(content_dir: PathBuf, path_info: &str) -> PathBuf {
 }
 
 /// Fetch all pages.
-/// 
+///
 /// If show_unpublished is `true`, this will include pages that Bartholomew has determined are
 /// unpublished.
-pub fn all_pages(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<BTreeMap<String, PageValues>> {
+pub fn all_pages(
+    dir: PathBuf,
+    show_unpublished: bool,
+) -> anyhow::Result<BTreeMap<String, PageValues>> {
     let files = all_files(dir)?;
     let mut contents = BTreeMap::new();
     for f in files {
         // Dotfiles should not be loaded.
-        if f.file_name().map(|f| f.to_string_lossy().starts_with(".")).unwrap_or(false) {
+        if f.file_name()
+            .map(|f| f.to_string_lossy().starts_with('.'))
+            .unwrap_or(false)
+        {
             eprintln!("Skipping dotfile {:?}", f);
             continue;
         }
-        let raw_data = std::fs::read_to_string(&f).map_err(|e| anyhow::anyhow!("File is not string data: {:?}: {}", &f, e))?;
+        let raw_data = std::fs::read_to_string(&f)
+            .map_err(|e| anyhow::anyhow!("File is not string data: {:?}: {}", &f, e))?;
         match raw_data.parse::<Content>() {
             Ok(content) => {
                 if show_unpublished || content.published {
                     contents.insert(f.to_string_lossy().to_string(), content.into());
                 }
-            },
+            }
             Err(e) => {
                 // If a parse fails, don't take down the entire site. Just skip this piece of content.
                 eprintln!("File {:?}: {}", &f, e);
-                continue
+                continue;
             }
         }
     }
@@ -100,7 +103,7 @@ pub fn all_pages(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<BTreeMa
 }
 
 /// Fetch a list of paths to every file in the directory
-/// 
+///
 /// Note that this will return files that contain unpublished content, as publish state cannot be determined
 /// until a file has been read.
 pub fn all_files(dir: PathBuf) -> anyhow::Result<Vec<PathBuf>> {
@@ -136,36 +139,41 @@ pub struct Content {
     /// The unparsed Markdown for this content.
     pub body: String,
     /// The published state.
-    /// 
+    ///
     /// Published state is determined when a new Content is created.
     /// It is determined according to the following rules:
-    /// 
+    ///
     /// - If the front matter explicitly sets a publish state (`head.published`), this MUST reflect that.
     /// - Else if a date is present in the front matter (`head.date`), then...
     ///   - If the date is in the future, `published` is `false`
     ///   - Otherwise, it is `true`
     /// - Else content is considered to be published.
-    /// 
+    ///
     /// Practically speaking, what this means is that content is published by default.
     pub published: bool,
 }
 
 impl Content {
-
     /// Create new content from a head and a body.
     ///
     /// This determines published state based on the head.
     ///
     /// The environment is copied from the system environment. This is safe when executed inside of Wagi or a WASI runtime.
     pub fn new(head: Head, body: String) -> Self {
-        let pdate = head.date.clone();
+        let pdate = head.date;
 
         // If explicitly published in the front matter, mark it published
         // Else if date is set, and the date is not in the future, it's published...
         // Else if no date is set, mark it published
-        let published = head.published.unwrap_or_else(|| pdate.map(|d|d <= Utc::now()).unwrap_or(true));
+        let published = head
+            .published
+            .unwrap_or_else(|| pdate.map(|d| d <= Utc::now()).unwrap_or(true));
 
-        Content { head, body, published }
+        Content {
+            head,
+            body,
+            published,
+        }
     }
 
     /// Render the body using a Markdown renderer
@@ -185,9 +193,10 @@ impl FromStr for Content {
     type Err = anyhow::Error;
     fn from_str(full_document: &str) -> Result<Self, Self::Err> {
         let (toml_text, body) = full_document
-            .split_once(DOC_SEPERATOR)
-            .unwrap_or(("title = 'Untitled'", &full_document));
-        let head: Head = toml::from_str(toml_text).map_err(|e| anyhow::anyhow!("TOML parsing error: {}", e))?;
+            .split_once(DOC_SEPARATOR)
+            .unwrap_or(("title = 'Untitled'", full_document));
+        let head: Head =
+            toml::from_str(toml_text).map_err(|e| anyhow::anyhow!("TOML parsing error: {}", e))?;
 
         Ok(Content::new(head, body.to_owned()))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod content;
+pub mod response;
+pub mod template;

--- a/src/response.rs
+++ b/src/response.rs
@@ -44,7 +44,7 @@ pub fn send_gzip_result(
     if let Some(status) = status_opt {
         println!("Status: {}", status);
     }
-    println!("Content-Encoding: {}", "gzip");
+    println!("Content-Encoding: gzip");
     println!("Content-Type: {}\n", content_type);
 
     let mut e = GzEncoder::new(Vec::new(), Compression::default());

--- a/src/template.rs
+++ b/src/template.rs
@@ -29,11 +29,11 @@ pub struct TemplateContext {
     page: PageValues,
     site: SiteValues,
     /// A copy of the environment variables
-    /// 
+    ///
     /// Unlike a static site generator, Bartholomew can make decisions based on request.
     /// This provides templates with access to the request data along with custom
     /// environment variables.
-    /// 
+    ///
     /// TODO: Should there be a way to filter out env vars that should never get to
     /// the template layer? As of this writing, there are no such variables, but in
     /// the future there could be.
@@ -111,10 +111,13 @@ impl<'a> Renderer<'a> {
             // Relative file name without extension. Note that we skip any file
             // that doesn't have this.
             if let Some(fn_name) = script.file_stem() {
-                eprintln!("scripts: registering {}", fn_name.to_str().unwrap_or("unknown"));
+                eprintln!(
+                    "scripts: registering {}",
+                    fn_name.to_str().unwrap_or("unknown")
+                );
                 self.handlebars
                     .register_script_helper_file(&fn_name.to_string_lossy(), &script)
-                    .map_err(|e|anyhow::anyhow!("Script {:?}: {}", &script, e))?;
+                    .map_err(|e| anyhow::anyhow!("Script {:?}: {}", &script, e))?;
             }
         }
 
@@ -154,8 +157,10 @@ impl<'a> Renderer<'a> {
             // Copy the WASI env into the env template var.
             env: std::env::vars().collect(),
         };
-        let out = self.handlebars.render(&tpl, &ctx)
-            .map_err(|e|anyhow::anyhow!("Template '{}': {}", &tpl, e))?;
+        let out = self
+            .handlebars
+            .render(&tpl, &ctx)
+            .map_err(|e| anyhow::anyhow!("Template '{}': {}", &tpl, e))?;
         Ok(out)
     }
 


### PR DESCRIPTION
close #45 

This commit adds a new CLI that simplifies working with Bartholomew
websites.

This initial commit adds a `bart calendar` command 
(based on https://github.com/fermyon/bartcal)  that lists 
the content and its publishing schedule, as well as a `bart new post`
command that helps with the task of creating new posts.

Usage:

```
 ➜ bart calendar ./content
Wed, Dec 22, 2021 - 'Documentation' index.md
Thu, Dec 23, 2021 - 'First Post!' 2021-12-23-first-post.md
Thu, Dec 23, 2021 - 'What Is Markdown?' 2021-12-23-what-is-markdown.md
Thu, Dec 23, 2021 - 'Markdown examples' markdown.md

 ➜ bart new post content/blog --author "Radu Matei" --template abc --title "Writing a new post using Bart"
Wrote new post in file content/blog/untitled.md
```

Signed-off-by: Radu Matei <radu.matei@fermyon.com>