### PR TITLE
fix: remove HTML minification to avoid line break issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,6 @@ dependencies = [
  "flate2",
  "handlebars",
  "handlebars_sprig",
- "minify",
  "pulldown-cmark",
  "serde",
  "serde_json",
@@ -336,12 +335,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "minify"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93bacfc6ce0cf3e41da4d9415904090e1f7ca8d105c1396907f78d8fee42635"
 
 [[package]]
 name = "miniz_oxide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ chrono = {version = "0.4", features = ["serde"]}
 flate2 = "1.0"
 handlebars = {version = "4.1", features = ["dir_source", "script_helper"]}
 handlebars_sprig = { version = "0.2.0" }
-minify = "1.2"
 pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,12 +132,9 @@ fn exec() -> anyhow::Result<()> {
                         .clone()
                         .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_owned());
 
-                    let mut data = engine
+                    let data = engine
                         .render_template(doc, config)
                         .map_err(|e| anyhow::anyhow!("Rendering {:?}: {}", &content_path, e))?;
-                    if content_type.starts_with("text/html") {
-                        data = minify::html::minify(&data);
-                    }
 
                     if gzip_encoding {
                         response::send_gzip_result(path_info, data, content_type, status_opt);


### PR DESCRIPTION
Minifying the HTML output results in line endings not being rendered as
spaces, which makes the final output unreadable.

Given we already GZIP the content, minification seems like a redundant
step, and this commit removes it entirely.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>