### PR TITLE
feat: :sparkles: Allow markdown to include rhai script shortcodes.

### DIFF
--- a/content/blog/2021-12-23-goals-of-bartholomew.md
+++ b/content/blog/2021-12-23-goals-of-bartholomew.md
@@ -7,6 +7,7 @@ author = "Matt Butcher"
 author_page = "/author/butcher"
 ---
 
+
 Bartholomew is intended to be three things:
 
 1. A simple-to-use CMS-like system that feels like Jekyll or other static site generators
@@ -23,6 +24,9 @@ just written in plain text, and is rendered into HTML. Menus and navigation are
 built up automatically. And dealing with images and other files is as easy as dropping
 a file in a directory. We love that experience. So we tried to combine the best of the
 static site generator with a server-side technology.
+
+{{ alert "warning" "Bartholomew is a work in progress" }}
+
 
 Bartholomew works like PHP (the language Wordpress and Drupal are written in). Each
 time the server receives a request, it starts up a new Bartholomew instance, which only

--- a/modules.toml
+++ b/modules.toml
@@ -6,4 +6,4 @@ volumes = {"/" = "static/"}
 [[module]]
 module = "target/wasm32-wasi/release/bartholomew.wasm"
 route = "/..."
-volumes = { "content/" = "content/" , "templates/" = "templates/", "scripts/" = "scripts/", "config/" = "config/"}
+volumes = { "content/" = "content/" , "templates/" = "templates/", "shortcodes/" = "shortcodes/", "scripts/" = "scripts/", "config/" = "config/"}

--- a/shortcodes/alert.rhai
+++ b/shortcodes/alert.rhai
@@ -1,0 +1,38 @@
+let type = params[0];
+let msg = params[1];
+
+
+let colors = #{
+  primary:`alert-primary`,
+  success:`alert-success`,
+  warning: `alert-warning`,
+  danger: `alert-danger`,
+};
+
+let icons = #{
+  primary:`#info-fill`,
+  success:`#check-circle-fill`,
+  warning: `#exclamation-triangle-fill`,
+  danger: `#exclamation-triangle-fill`,
+};
+
+
+`<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="check-circle-fill" fill="currentColor" viewBox="0 0 16 16">
+    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+  </symbol>
+  <symbol id="info-fill" fill="currentColor" viewBox="0 0 16 16">
+    <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+  </symbol>
+  <symbol id="exclamation-triangle-fill" fill="currentColor" viewBox="0 0 16 16">
+    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+  </symbol>
+</svg>
+
+<div class="alert ` + colors[type] + ` d-flex align-items-center" role="alert">
+  <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Info:"><use xlink:href="` + icons[type]  +`"/></svg>
+  <div>
+` + msg + `
+  </div>
+</div>
+`

--- a/src/content.rs
+++ b/src/content.rs
@@ -196,12 +196,12 @@ impl <'a> Content<'a>{
             // that doesn't have this.
             if let Some(fn_name) = script.file_stem() {
                 eprintln!(
-                    "scripts: registering {}",
+                    "shortcodes: registering {}",
                     fn_name.to_str().unwrap_or("unknown")
                 );
                 self.handlebars
                     .register_script_helper_file(&fn_name.to_string_lossy(), &script)
-                    .map_err(|e| anyhow::anyhow!("Script {:?}: {}", &script, e))?;
+                    .map_err(|e| anyhow::anyhow!("Shortcode {:?}: {}", &script, e))?;
             }
         }
 
@@ -226,7 +226,7 @@ impl <'a> Content<'a>{
                 // print the error
                 eprintln!("Error rendering markdown: {}", e);
                 // return nothing
-                "Template Error".to_string()
+                e.to_string()
             });
 
         // Might as well turn on all the lights on the Christmas tree

--- a/src/template.rs
+++ b/src/template.rs
@@ -58,8 +58,8 @@ pub struct PageValues {
     pub published: bool,
 }
 
-impl From<Content> for PageValues {
-    fn from(c: Content) -> Self {
+impl<'a> From<Content<'a>> for PageValues {
+    fn from(mut c: Content) -> Self {
         PageValues {
             body: c.render_markdown(),
             head: c.head,


### PR DESCRIPTION
This change processes the markdown with handlebars templates using scripts in the "shortcodes" directory, allowing content authors to include shortcodes in their markdown.

Thanks for considering this feature!