### PR TITLE
Add 'bart check' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,20 @@ Thu, Dec 23, 2021 - 'Markdown examples' markdown.md
 
  ➜ bart new post content/blog --author "Radu Matei" --template abc --title "Writing a new post using Bart"
 Wrote new post in file content/blog/untitled.md
+
+ ➜ bart check content/* content/blog/*
+✅ content/atom.md
+✅ content/blog.md
+✅ content/functions_example.md
+✅ content/helpers_example.md
+✅ content/index.md
+✅ content/markdown.md
+✅ content/redirect_example.md
+✅ content/robots.md
+✅ content/sitemap.md
+✅ content/tag.md
+❌ content/blog/2021-12-23-first-post.md        Could not parse file "content/blog/2021-12-23-first-post.md": TOML parsing error: trailing input for key `date` at line 3 column 8
+✅ content/blog/2021-12-23-goals-of-bartholomew.md
+✅ content/blog/2021-12-23-what-is-markdown.md
+Error: One or more pieces of content are invalid
 ```

--- a/bart/src/commands/calendar.rs
+++ b/bart/src/commands/calendar.rs
@@ -23,7 +23,7 @@ impl CalendarCommand {
     pub async fn run(self) -> Result<()> {
         let now = Utc::now();
 
-        // Print a content calendar for every given director.
+        // Print a content calendar for every given directory.
         for dir in self.paths {
             // Walk the content directory.
             let files = content::all_files(dir)?;

--- a/bart/src/commands/check.rs
+++ b/bart/src/commands/check.rs
@@ -20,14 +20,21 @@ impl CheckCommand {
         let mut exit_with_err = false;
         for file_path in self.paths {
             if file_path.is_dir() {
-                continue
+                continue;
             }
             match check_file(&file_path).await {
-                Ok(()) => println!("✅ {}", &file_path.to_str().unwrap_or("").color(Color::Green)),
+                Ok(()) => println!(
+                    "✅ {}",
+                    &file_path.to_str().unwrap_or("").color(Color::Green)
+                ),
                 Err(e) => {
-                    println!("❌ {}\t{}", &file_path.to_str().unwrap_or("").color(Color::Red), e);
+                    println!(
+                        "❌ {}\t{}",
+                        &file_path.to_str().unwrap_or("").color(Color::Red),
+                        e
+                    );
                     exit_with_err = true;
-                },
+                }
             }
         }
         if exit_with_err {
@@ -36,15 +43,15 @@ impl CheckCommand {
         } else {
             Ok(())
         }
-        
     }
-
-    
 }
 
 async fn check_file(p: &Path) -> Result<()> {
-    let raw_data = std::fs::read_to_string(p).map_err(|e| anyhow::anyhow!("Could not read file {:?} as a string: {}", &p, e))?;
-    let content: Content = raw_data.parse().map_err(|e| anyhow::anyhow!("Could not parse file {:?}: {}", &p, e))?;
+    let raw_data = std::fs::read_to_string(p)
+        .map_err(|e| anyhow::anyhow!("Could not read file {:?} as a string: {}", &p, e))?;
+    let content: Content = raw_data
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Could not parse file {:?}: {}", &p, e))?;
 
     // This will catch (only) panic cases.
     let _html = content.render_markdown();
@@ -56,8 +63,12 @@ async fn check_file(p: &Path) -> Result<()> {
 
     if let Some(tpl) = content.head.template {
         let tpl_path = Path::new("templates").join(format!("{}.hbs", &tpl));
-        if let Err(e)  = std::fs::metadata(&tpl_path) {
-            return Err(anyhow::anyhow!("Failed to open template {:?}: {}", tpl_path, e))
+        if let Err(e) = std::fs::metadata(&tpl_path) {
+            return Err(anyhow::anyhow!(
+                "Failed to open template {:?}: {}",
+                tpl_path,
+                e
+            ));
         }
     }
 

--- a/bart/src/commands/mod.rs
+++ b/bart/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod calendar;
 pub mod new;
+pub mod check;

--- a/bart/src/commands/mod.rs
+++ b/bart/src/commands/mod.rs
@@ -1,3 +1,3 @@
 pub mod calendar;
-pub mod new;
 pub mod check;
+pub mod new;

--- a/bart/src/main.rs
+++ b/bart/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use commands::{calendar::CalendarCommand, new::NewCommand, check::CheckCommand};
+use commands::{calendar::CalendarCommand, check::CheckCommand, new::NewCommand};
 use structopt::{clap::AppSettings, StructOpt};
 
 mod commands;

--- a/bart/src/main.rs
+++ b/bart/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use commands::{calendar::CalendarCommand, new::NewCommand};
+use commands::{calendar::CalendarCommand, new::NewCommand, check::CheckCommand};
 use structopt::{clap::AppSettings, StructOpt};
 
 mod commands;
@@ -24,6 +24,7 @@ async fn main() -> Result<()> {
     ])]
 enum BartApp {
     Calendar(CalendarCommand),
+    Check(CheckCommand),
     New(NewCommand),
 }
 
@@ -32,6 +33,7 @@ impl BartApp {
     pub async fn run(self) -> Result<()> {
         match self {
             BartApp::Calendar(cmd) => cmd.run().await,
+            BartApp::Check(cmd) => cmd.run().await,
             BartApp::New(cmd) => cmd.run().await,
         }
     }


### PR DESCRIPTION
Added `bart check` command, which takes a piece of Markdown/TOML content and runs a few tests to make sure it is okay to publish.

Example:

```console
$ bart check content/* content/blog/*
✅ content/atom.md
✅ content/blog.md
✅ content/functions_example.md
✅ content/helpers_example.md
✅ content/index.md
✅ content/markdown.md
✅ content/redirect_example.md
✅ content/robots.md
✅ content/sitemap.md
✅ content/tag.md
❌ content/blog/2021-12-23-first-post.md        Could not parse file "content/blog/2021-12-23-first-post.md": TOML parsing error: trailing input for key `date` at line 3 column 8
✅ content/blog/2021-12-23-goals-of-bartholomew.md
✅ content/blog/2021-12-23-what-is-markdown.md
```

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>