### PR TITLE
Check that title is not unset or set to default

### DIFF
--- a/bart/src/commands/check.rs
+++ b/bart/src/commands/check.rs
@@ -62,9 +62,9 @@ async fn check_file(p: &Path) -> Result<()> {
     // - Warn if there is a publish date
 
     if content.head.title.len() == 0 {
-        return anyhow::bail!("Title should not be empty");
+        anyhow::bail!("Title should not be empty");
     } else if content.head.title == "Untitled" {
-        return anyhow::bail!("Document seems to be missing title. Is there TOML metadata?");
+        anyhow::bail!("Document seems to be missing title. Is there TOML metadata?");
     }
 
     if let Some(tpl) = content.head.template {

--- a/bart/src/commands/check.rs
+++ b/bart/src/commands/check.rs
@@ -61,6 +61,12 @@ async fn check_file(p: &Path) -> Result<()> {
     // - Check that date parses correctly (Actually, is done already)
     // - Warn if there is a publish date
 
+    if content.head.title.len() == 0 {
+        return Err(anyhow::anyhow!("Title should not be empty"))
+    } else if content.head.title == "Untitled" {
+        return Err(anyhow::anyhow!("Document seems to be missing title. Is there TOML metadata?"))
+    }
+
     if let Some(tpl) = content.head.template {
         let tpl_path = Path::new("templates").join(format!("{}.hbs", &tpl));
         if let Err(e) = std::fs::metadata(&tpl_path) {

--- a/bart/src/commands/check.rs
+++ b/bart/src/commands/check.rs
@@ -62,9 +62,9 @@ async fn check_file(p: &Path) -> Result<()> {
     // - Warn if there is a publish date
 
     if content.head.title.len() == 0 {
-        return Err(anyhow::anyhow!("Title should not be empty"))
+        return anyhow::bail!("Title should not be empty");
     } else if content.head.title == "Untitled" {
-        return Err(anyhow::anyhow!("Document seems to be missing title. Is there TOML metadata?"))
+        return anyhow::bail!("Document seems to be missing title. Is there TOML metadata?");
     }
 
     if let Some(tpl) = content.head.template {


### PR DESCRIPTION
This adds two minor tests to `bart check` to make sure that the title isn't empty or set to the default

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>