### PR TITLE
fix: convert relative links to web-friendly URIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ bart:
 
 .PHONY: test
 test:
+	cargo test --all --no-fail-fast -- --nocapture
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo fmt --all -- --check
 


### PR DESCRIPTION
This patch converts any links of the form "./\<name\>.md" or "\<name\>.md" into
"/\<name\>".  In other words, it does the opposite of what `content::content_path`
does when handling links.

This fixes https://github.com/fermyon/bartholomew/issues/69.

Signed-off-by: Joel Dice <joel.dice@gmail.com>