### PR TITLE
refactor: make `maybe_translate_relative_link` more concise

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{read_dir, DirEntry};
-use std::iter;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -136,15 +135,9 @@ fn visit_files(dir: PathBuf, cb: &mut dyn FnMut(&DirEntry)) -> anyhow::Result<()
 fn maybe_translate_relative_link(dest: markdown::CowStr) -> markdown::CowStr {
     if let Some(dest) = dest.strip_suffix(".md") {
         if let Some(dest) = dest.strip_prefix("./") {
-            return iter::once('/')
-                .chain(dest.chars())
-                .collect::<String>()
-                .into();
+            return format!("/{dest}").into();
         } else if !dest.contains('/') {
-            return iter::once('/')
-                .chain(dest.chars())
-                .collect::<String>()
-                .into();
+            return format!("/{dest}").into();
         }
     }
 


### PR DESCRIPTION
I went overboard using iterators in my previous commit, making the code more
verbose than it needed to be.  This simplifies it.

Signed-off-by: Joel Dice <joel.dice@gmail.com>