### PR TITLE
feat(bart): add bart new site command

### DIFF
--- a/bart/src/commands/new.rs
+++ b/bart/src/commands/new.rs
@@ -38,7 +38,7 @@ pub struct NewPostCommand {
     #[structopt(long = "description")]
     pub description: Option<String>,
     /// Template for the post.
-    #[structopt(long = "template", default_value = "blog")]
+    #[structopt(long = "template", default_value = "main")]
     pub template: String,
     /// Type of the post.
     #[structopt(long = "type", default_value = "post")]


### PR DESCRIPTION
This commit adds a new bart command for creating a new website from a git repo.
The command, `bart new site --git <URL> <dir>` can be used to create new sites
from template repositories.

Documentation will be added in a separate commit that tackles the documentation
website.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>