### PR TITLE
ci(*): add docs check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,7 @@ jobs:
       - name: Test
         run: |
           make test
+
+      - name: Check Docs
+        run: |
+          make check-content

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ test:
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo fmt --all -- --check
 
+.PHONY: check-content
+check-content:
+	cd docs && ../target/release/bart check content/**
+
 .PHONY: serve
 serve: build
 serve:


### PR DESCRIPTION
* Adds a step in the build workflow to check the docs content via... `bart` of course!

cc @tpmccallum 