### PR TITLE
Add request headers to template Context

### DIFF
--- a/docs/content/templates.md
+++ b/docs/content/templates.md
@@ -107,7 +107,29 @@ You can dump the entire contents of `env` using a template like this:
 </ul>
 ```
 
-Note that very little data validation is done on incoming environment variables, so you should validate or scrub any values before showing them to the user.
+### The `request` object
+
+The fourth top-level object is `request`, which holds all the details about
+the HTTP request, the path of this resource, and other Spin information.
+
+The `request` object is a set of keys and values:
+
+```
+{
+    spin-full-url: "http://localhost:3000/test"
+    ...
+}
+```
+
+You can dump the entire contents of `request` using a template like this:
+
+```
+<ul>
+    {{#each request}}
+    <li><code>{{@key}}</code>: <code>"{{this}}"</code></li>
+    {{/each}}
+</ul>
+```
 
 ## Including a template
 

--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -76,7 +76,7 @@ pub fn render(req: Request) -> Result<Response> {
                 );
                 let err_vals =
                     template::error_values("Not Found", "The requested page was not found.");
-                let body = engine.render_template(err_vals, config)?;
+                let body = engine.render_template(err_vals, config, req.headers().to_owned())?;
                 return response::not_found(path_info, body);
             }
 
@@ -97,7 +97,7 @@ pub fn render(req: Request) -> Result<Response> {
                         .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_owned());
 
                     let data = engine
-                        .render_template(doc, config)
+                        .render_template(doc, config, req.headers().to_owned())
                         .map_err(|e| anyhow!("Rendering {:?}: {}", &content_path, e))?;
 
                     let content_encoding = req.headers().get(http::header::ACCEPT_ENCODING);
@@ -108,7 +108,7 @@ pub fn render(req: Request) -> Result<Response> {
         }
         Err(_) => {
             let err_vals = template::error_values("Not Found", "The requested page was not found.");
-            let body = engine.render_template(err_vals, config)?;
+            let body = engine.render_template(err_vals, config, req.headers().to_owned())?;
             response::not_found(path_info, body)
         }
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 use super::content::{Content, Head};
 use handlebars::Handlebars;
-use serde::{Deserialize, Serialize};
 use http::HeaderMap;
+use serde::{Deserialize, Serialize};
 
 use handlebars_sprig;
 


### PR DESCRIPTION
Add the HTTP request headers into the template context to allow for the capability of more dynamic rendering in the templates. #85 