### PR TITLE
Remove excess MD parsing

### DIFF
--- a/bart/src/commands/new.rs
+++ b/bart/src/commands/new.rs
@@ -87,6 +87,7 @@ Begin with intro paragraph
             head,
             body,
             published: true,
+            is_requested: false,
         };
 
         let content = serialize_content(&content)?;

--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -76,8 +76,8 @@ pub fn render(req: Request) -> Result<Response> {
 
     match std::fs::read_to_string(&content_path) {
         Ok(full_document) => {
-            let doc: content::Content = full_document.parse()?;
-
+            let mut doc: content::Content = full_document.parse()?;
+            doc.is_requested = true;
             // Hide unpublished content unless PREVIEW_MODE is on.
             if !doc.published && !preview_mode {
                 eprintln!(

--- a/src/content.rs
+++ b/src/content.rs
@@ -180,6 +180,8 @@ pub struct Content {
     ///
     /// Practically speaking, what this means is that content is published by default.
     pub published: bool,
+    /// Flag to specify if this file was the requested content
+    pub is_requested: bool,
 }
 
 impl Content {
@@ -202,6 +204,7 @@ impl Content {
             head,
             body,
             published,
+            is_requested: false,
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -63,7 +63,10 @@ pub struct PageValues {
 impl From<Content> for PageValues {
     fn from(c: Content) -> Self {
         PageValues {
-            body: c.render_markdown(),
+            body: match c.is_requested {
+                true => c.render_markdown(),
+                _ => String::from(""),
+            },
             head: c.head,
             published: c.published,
         }


### PR DESCRIPTION
This PR optimizes rendering by removing the markdown parsing on all the content files except the requested document as per #92. Does not introduce any breaking API changes but breaks content. Any references to `site.pages[i].body` will be empty.

Signed-off-by: Karthik Ganeshram <karthik.ganeshram@fermyon.com>