### PR TITLE
Feat: optional indexing and caching of `site.pages`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /modules/*.wasm
 /logs
 node_modules/
+/config/_cache.json

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SPIN ?= spin
 # If PREVIEW_MODE is on then unpublished content will be displayed.
 PREVIEW_MODE ?= 0
 SHOW_DEBUG ?= 1
+DISABLE_CACHE ?= 1
 BASE_URL ?= http://localhost:3000
 
 .PHONY: build
@@ -31,7 +32,11 @@ check-content:
 .PHONY: serve
 serve: build
 serve:
-	$(SPIN) up --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG) -e BASE_URL=$(BASE_URL) -f docs/spin.toml
+	$(SPIN) up --log-dir ./logs -e PREVIEW_MODE=$(PREVIEW_MODE) -e SHOW_DEBUG=$(SHOW_DEBUG) -e BASE_URL=$(BASE_URL) -e DISABLE_CACHE=$(DISABLE_CACHE) -f docs/spin.toml
 
 .PHONY: run
 run: serve
+
+.PHONY: clean
+clean:
+	rm -rf config/_cache.json

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ Make:
 $ PREVIEW_MODE=1 make serve
 ```
 
+### The Page Cache
+
+Unless the environment variable `-e DISABLE_CACHE=1` is set, the first load of a site will create a cache
+of page metadata in `config/_cache.json`. This is an optimization to reduce the number of file IO operations
+Bartholomew needs to make.
+
+If you are actively developing content, we suggest setting `DISABLE_CACHE=1`. By default, the `Makefile`'s `make serve`
+target disables the cache, as `make serve` is assumed to be used only for developers.
+
 ## Configuring Bartholomew
 
 Bartholomew can run inside of any Spin environment that supports directly executing

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -17,6 +17,7 @@ title = "Bartholomew"
 base_url = "http://localhost:3000"
 about = "This site is generated with Bartholomew, the Spin micro-CMS. And this message is in site.toml."
 theme = "fermyon"
+index_site_pages = ["main"]
 enable_shortcodes = false
 
 [extra]
@@ -34,6 +35,7 @@ It has a few pre-defined fields:
 - base_url: a base URL that templates can use to construct full URLs to content. This can be overridden by setting the `-e BASE_URL="https://example.com"` environment variable for Spin.
 - about: a brief description of the site
 - theme: the name of the theme for the website from the `/themes/` folder
+- index_site_pages: A list of templates that require `site.pages` to be populated.
 - enable_shortcodes: Allows addition of shortcodes in the markdown content using rhai scripts. Defaults to false.
 
 You can define your own fields in the `[extra]` section. Anything in `[extra]` is not

--- a/docs/content/templates.md
+++ b/docs/content/templates.md
@@ -61,7 +61,7 @@ the `extra` section, we use `{{ page.head.extra.key }}`.
 
 ### The `site` object
 
-In addition to the `page` object, there is also a `site` object:
+In addition to the `page` object, there is also a `site` object. `site.pages` contains the `head` section and content of every page in the site. `site.pages` is only populated for templates included in `index_site_pages` in `site.toml` as described in the [configuration section](/configuration.md) 
 
 ```
 {
@@ -81,7 +81,7 @@ In addition to the `page` object, there is also a `site` object:
 ```
 
 Note that the `site.pages` array has access to every single document in the `content` folder.
-This part of the API may change in the future, as it does not scale terribly well.
+This part of the API may change in the future, as it does not scale terribly well. 
 
 ### The `env` object
 

--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -19,6 +19,13 @@ pub fn render(req: Request) -> Result<Response> {
         }
         _ => false,
     };
+    let disable_cache = match std::env::var("DISABLE_CACHE") {
+        Ok(val) if val == "1" => {
+            eprintln!("INFO: Bartholomew is running with DISABLE_CACHE=1");
+            true
+        }
+        _ => false,
+    };
 
     // Get the request path.
     let path_info = match req.headers().get("spin-path-info") {
@@ -61,6 +68,7 @@ pub fn render(req: Request) -> Result<Response> {
 
     // If running in preview mode, show unpublished content.
     engine.show_unpublished = preview_mode;
+    engine.disable_cache = disable_cache;
 
     // Load the template directory.
     engine.load_template_dir()?;


### PR DESCRIPTION
This is a ***breaking*** change with a change required in `site.toml` to fix.

Initial implementation of having the ability to index content for `site.pages` for only required templates. Implement the cache proposed in #15 for `site.pages` to improve performance.

Optional indexing improves the performance of pages that do not depend on `site.toml` while caching improves the performance of any that uses it.

The templates for which `site.pages` list is required can be specified in `site.toml` as

```
.
.
index_site_pages  = ["main"]

[extra] 
.
.
```

TODO: Docs. 

Some initial performance results for tests on fermyon.com

## Optional indexing

**This branch**

```
bombardier -c 1 -n 1000 http://localhost:3000/blog/underprovisioning-cloud-services
Bombarding http://localhost:3000/blog/underprovisioning-cloud-services with 1000 request(s) using 1 connection(s)
 1000 / 1000 [=========================================================] 100.00% 76/s 13s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        77.46      26.13     261.02
  Latency       12.96ms   829.78us    23.75ms
  HTTP codes:
    1xx - 0, 2xx - 1000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.43MB/s
```

**main branch**

```
bombardier -c 1 -n 1000 http://localhost:3000/blog/underprovisioning-cloud-services
Bombarding http://localhost:3000/blog/underprovisioning-cloud-services with 1000 request(s) using 1 connection(s)
 1000 / 1000 [=========================================================] 100.00% 45/s 21s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        45.79       4.47      69.55
  Latency       21.85ms     0.96ms    35.97ms
  HTTP codes:
    1xx - 0, 2xx - 1000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     2.04MB/s
```

## Caching `site.pages`
**This branch**
```
bombardier -c 1 -n 1000 http://localhost:3000/blog/index
Bombarding http://localhost:3000/blog/index with 1000 request(s) using 1 connection(s)
 1000 / 1000 [=========================================================] 100.00% 51/s 19s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        52.47      21.15     620.55
  Latency       19.25ms     1.77ms    64.88ms
  HTTP codes:
    1xx - 0, 2xx - 1000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     5.07MB/s
```
**main branch**
```
bombardier -c 1 -n 1000 http://localhost:3000/blog/index
Bombarding http://localhost:3000/blog/index with 1000 request(s) using 1 connection(s)
 1000 / 1000 [=========================================================] 100.00% 32/s 30s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        33.00      13.88      65.60
  Latency       30.29ms     4.16ms    81.09ms
  HTTP codes:
    1xx - 0, 2xx - 1000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.22MB/s
```

Note: To test locally on fermyon.com add the following to `site.toml` when using `bartholomew.wasm` module from this branch to test caching with either homepage or blog page.

```
index_site_pages = ["home", "main"]
```
