### PR TITLE
Prepare for release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bart"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bartholomew",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "bartholomew"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "brotli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bartholomew"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 

--- a/bart/Cargo.toml
+++ b/bart/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bart"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 

--- a/release-process.md
+++ b/release-process.md
@@ -3,7 +3,7 @@
 To cut a release of Bartholomew, you will need to do the following:
 
 1. Create a pull request that changes the version number for your new version (e.g. 1.2.2 becomes 1.2.3)
-    - `Cargo.toml` is the most important place to make this change
+    - `Cargo.toml` and `bart/Cargo.toml` are the most important places to make this change
     - Check the docs for hard-coded version strings
 2. Merge the PR created in #1 (Such PRs are still required to get approvals, so make sure you get signoff on the PR)
 3. Create a new tag with a `v` and then the version number (`v1.2.3`)


### PR DESCRIPTION
The `bartholomew.wasm` and `bart` CLI have been version aligned. The release process has also been updated to reflect the aligning of versions.