### PR TITLE
update sprig  to use spin sdk for outbound calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "pulldown-cmark 0.9.1",
  "serde",
  "serde_json",
- "spin-sdk",
+ "spin-sdk 0.3.0",
  "toml",
  "wit-bindgen-rust",
 ]
@@ -263,6 +263,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,9 +310,8 @@ dependencies = [
 
 [[package]]
 name = "handlebars_sprig"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336c899970e48ab2ff02b27210c1793fd0d279389b02e3c6bef46390c13d78ea"
+version = "0.4.0"
+source = "git+https://github.com/rajatjindal/handlebars-sprig?rev=ac179552db4ed525e6e453a998140b1abb259b14#ac179552db4ed525e6e453a998140b1abb259b14"
 dependencies = [
  "chrono",
  "handlebars",
@@ -310,7 +319,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "wasi-experimental-http 0.7.0",
+ "spin-sdk 0.4.0",
 ]
 
 [[package]]
@@ -408,6 +417,12 @@ checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -519,6 +534,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
@@ -867,6 +888,22 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
+source = "git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6#232567f2b6c6b6d8145b5a7fdd42452ed69639e6"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "http",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust-wasm",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "spin-macro"
+version = "0.1.0"
 source = "git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8#4c6ec40ef8b518c1e901a476c752ad961525bef8"
 dependencies = [
  "anyhow",
@@ -888,8 +925,21 @@ dependencies = [
  "anyhow",
  "bytes",
  "http",
- "spin-macro",
- "wasi-experimental-http 0.9.0",
+ "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8)",
+ "wasi-experimental-http",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "spin-sdk"
+version = "0.4.0"
+source = "git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6#232567f2b6c6b6d8145b5a7fdd42452ed69639e6"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "form_urlencoded",
+ "http",
+ "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6)",
  "wit-bindgen-rust",
 ]
 
@@ -1219,19 +1269,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi-experimental-http"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8963a8332c5629657d8a5fde3d5ad0023b12f68be5dede069404d322c04957"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "wasi-experimental-http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 flate2 = "1.0.23"
 handlebars = { version = "4.2.2", features = ["dir_source", "script_helper"] }
-handlebars_sprig = "0.3.0"
+handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "ac179552db4ed525e6e453a998140b1abb259b14" }
 http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
fixes #109 