### PR TITLE
update handle bar sprig

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -33,4 +33,4 @@ jobs:
           token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
           repository: ${{ secrets.DEST_REPO }}
           event-type: bartholomew-docs-updated
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"event_type": "bartholomew-docs-updated", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "serde_json",
  "spin-sdk 0.3.0",
  "toml",
- "wit-bindgen-rust",
+ "wit-bindgen-rust 0.1.0",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "handlebars_sprig"
 version = "0.4.0"
-source = "git+https://github.com/rajatjindal/handlebars-sprig?rev=ac179552db4ed525e6e453a998140b1abb259b14#ac179552db4ed525e6e453a998140b1abb259b14"
+source = "git+https://github.com/rajatjindal/handlebars-sprig?rev=f2d42142121d4f04b35ce00fdd26ba48b0993fe0#f2d42142121d4f04b35ce00fdd26ba48b0993fe0"
 dependencies = [
  "chrono",
  "handlebars",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6#232567f2b6c6b6d8145b5a7fdd42452ed69639e6"
+source = "git+https://github.com/fermyon/spin?rev=139c40967a75dbdd5d4da2e626d24e68f54c0a5a#139c40967a75dbdd5d4da2e626d24e68f54c0a5a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -896,9 +896,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
- "wit-bindgen-rust",
+ "wit-bindgen-gen-core 0.2.0",
+ "wit-bindgen-gen-rust-wasm 0.2.0",
+ "wit-bindgen-rust 0.2.0",
 ]
 
 [[package]]
@@ -912,9 +912,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
- "wit-bindgen-rust",
+ "wit-bindgen-gen-core 0.1.0",
+ "wit-bindgen-gen-rust-wasm 0.1.0",
+ "wit-bindgen-rust 0.1.0",
 ]
 
 [[package]]
@@ -927,20 +927,20 @@ dependencies = [
  "http",
  "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8)",
  "wasi-experimental-http",
- "wit-bindgen-rust",
+ "wit-bindgen-rust 0.1.0",
 ]
 
 [[package]]
 name = "spin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6#232567f2b6c6b6d8145b5a7fdd42452ed69639e6"
+source = "git+https://github.com/fermyon/spin?rev=139c40967a75dbdd5d4da2e626d24e68f54c0a5a#139c40967a75dbdd5d4da2e626d24e68f54c0a5a"
 dependencies = [
  "anyhow",
  "bytes",
  "form_urlencoded",
  "http",
- "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=232567f2b6c6b6d8145b5a7fdd42452ed69639e6)",
- "wit-bindgen-rust",
+ "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=139c40967a75dbdd5d4da2e626d24e68f54c0a5a)",
+ "wit-bindgen-rust 0.2.0",
 ]
 
 [[package]]
@@ -1362,7 +1362,16 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
 dependencies = [
  "anyhow",
- "wit-parser",
+ "wit-parser 0.1.0",
+]
+
+[[package]]
+name = "wit-bindgen-gen-core"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+dependencies = [
+ "anyhow",
+ "wit-parser 0.2.0",
 ]
 
 [[package]]
@@ -1371,7 +1380,16 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
 dependencies = [
  "heck",
- "wit-bindgen-gen-core",
+ "wit-bindgen-gen-core 0.1.0",
+]
+
+[[package]]
+name = "wit-bindgen-gen-rust"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+dependencies = [
+ "heck",
+ "wit-bindgen-gen-core 0.2.0",
 ]
 
 [[package]]
@@ -1380,8 +1398,18 @@ version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
 dependencies = [
  "heck",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust",
+ "wit-bindgen-gen-core 0.1.0",
+ "wit-bindgen-gen-rust 0.1.0",
+]
+
+[[package]]
+name = "wit-bindgen-gen-rust-wasm"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+dependencies = [
+ "heck",
+ "wit-bindgen-gen-core 0.2.0",
+ "wit-bindgen-gen-rust 0.2.0",
 ]
 
 [[package]]
@@ -1391,7 +1419,17 @@ source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf
 dependencies = [
  "async-trait",
  "bitflags",
- "wit-bindgen-rust-impl",
+ "wit-bindgen-rust-impl 0.1.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "wit-bindgen-rust-impl 0.2.0",
 ]
 
 [[package]]
@@ -1401,14 +1439,37 @@ source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf
 dependencies = [
  "proc-macro2",
  "syn",
- "wit-bindgen-gen-core",
- "wit-bindgen-gen-rust-wasm",
+ "wit-bindgen-gen-core 0.1.0",
+ "wit-bindgen-gen-rust-wasm 0.1.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-impl"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "wit-bindgen-gen-core 0.2.0",
+ "wit-bindgen-gen-rust-wasm 0.2.0",
 ]
 
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "pulldown-cmark 0.8.0",
+ "unicode-normalization",
+ "unicode-xid",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.2.0"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
  "pulldown-cmark 0.9.1",
  "serde",
  "serde_json",
- "spin-sdk 0.3.0",
+ "spin-sdk",
  "toml",
- "wit-bindgen-rust 0.1.0",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "spin-sdk 0.4.0",
+ "spin-sdk",
 ]
 
 [[package]]
@@ -896,38 +896,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-gen-core 0.2.0",
- "wit-bindgen-gen-rust-wasm 0.2.0",
- "wit-bindgen-rust 0.2.0",
-]
-
-[[package]]
-name = "spin-macro"
-version = "0.1.0"
-source = "git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8#4c6ec40ef8b518c1e901a476c752ad961525bef8"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-gen-core 0.1.0",
- "wit-bindgen-gen-rust-wasm 0.1.0",
- "wit-bindgen-rust 0.1.0",
-]
-
-[[package]]
-name = "spin-sdk"
-version = "0.3.0"
-source = "git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8#4c6ec40ef8b518c1e901a476c752ad961525bef8"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=4c6ec40ef8b518c1e901a476c752ad961525bef8)",
- "wasi-experimental-http",
- "wit-bindgen-rust 0.1.0",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust-wasm",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -939,8 +910,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "http",
- "spin-macro 0.1.0 (git+https://github.com/fermyon/spin?rev=139c40967a75dbdd5d4da2e626d24e68f54c0a5a)",
- "wit-bindgen-rust 0.2.0",
+ "spin-macro",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -997,26 +968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1271,18 +1222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi-experimental-http"
-version = "0.9.0"
-source = "git+https://github.com/deislabs/wasi-experimental-http?rev=a82ae3d6c85c4251b3663035febeb8100068f51d#a82ae3d6c85c4251b3663035febeb8100068f51d"
-dependencies = [
- "anyhow",
- "bytes",
- "http",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,29 +1297,11 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "wit-bindgen-gen-core"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "anyhow",
- "wit-parser 0.1.0",
-]
-
-[[package]]
-name = "wit-bindgen-gen-core"
 version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "anyhow",
- "wit-parser 0.2.0",
-]
-
-[[package]]
-name = "wit-bindgen-gen-rust"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "heck",
- "wit-bindgen-gen-core 0.1.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1389,17 +1310,7 @@ version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "heck",
- "wit-bindgen-gen-core 0.2.0",
-]
-
-[[package]]
-name = "wit-bindgen-gen-rust-wasm"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "heck",
- "wit-bindgen-gen-core 0.1.0",
- "wit-bindgen-gen-rust 0.1.0",
+ "wit-bindgen-gen-core",
 ]
 
 [[package]]
@@ -1408,18 +1319,8 @@ version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460b51eb1d144b175b9aab9c50aba#cb871cfa1ee460b51eb1d144b175b9aab9c50aba"
 dependencies = [
  "heck",
- "wit-bindgen-gen-core 0.2.0",
- "wit-bindgen-gen-rust 0.2.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "async-trait",
- "bitflags",
- "wit-bindgen-rust-impl 0.1.0",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust",
 ]
 
 [[package]]
@@ -1429,18 +1330,7 @@ source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460
 dependencies = [
  "async-trait",
  "bitflags",
- "wit-bindgen-rust-impl 0.2.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-impl"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "proc-macro2",
- "syn",
- "wit-bindgen-gen-core 0.1.0",
- "wit-bindgen-gen-rust-wasm 0.1.0",
+ "wit-bindgen-rust-impl",
 ]
 
 [[package]]
@@ -1450,20 +1340,8 @@ source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=cb871cfa1ee460
 dependencies = [
  "proc-macro2",
  "syn",
- "wit-bindgen-gen-core 0.2.0",
- "wit-bindgen-gen-rust-wasm 0.2.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=dde4694aaa6acf9370206527a798ac4ba6a8c5b8#dde4694aaa6acf9370206527a798ac4ba6a8c5b8"
-dependencies = [
- "anyhow",
- "id-arena",
- "pulldown-cmark 0.8.0",
- "unicode-normalization",
- "unicode-xid",
+ "wit-bindgen-gen-core",
+ "wit-bindgen-gen-rust-wasm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
-spin-sdk = { git = "https://github.com/fermyon/spin", rev = "4c6ec40ef8b518c1e901a476c752ad961525bef8", optional = true }
+spin-sdk = { git = "https://github.com/fermyon/spin", rev = "139c40967a75dbdd5d4da2e626d24e68f54c0a5a", optional = true }
 toml = "0.5.9"
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dde4694aaa6acf9370206527a798ac4ba6a8c5b8", default-features = false }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba", default-features = false }
 
 [workspace]
 members = ["bart"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 flate2 = "1.0.23"
 handlebars = { version = "4.2.2", features = ["dir_source", "script_helper"] }
-handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "ac179552db4ed525e6e453a998140b1abb259b14" }
+handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "f2d42142121d4f04b35ce00fdd26ba48b0993fe0" }
 http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -280,6 +280,7 @@ Make:
 ```bash
 $ PREVIEW_MODE=1 make serve
 ```
+
 ### The Page Cache
 
 Unless the environment variable `-e DISABLE_CACHE=1` is set, the first load of a site will create a cache of page metadata in `config/_cache.json`. This is an optimization to reduce the number of file IO operations Bartholomew needs to make. If you are actively developing content, we suggest setting `DISABLE_CACHE=1`. By default, the `Makefile`'s `make serve` target disables the cache, as `make serve` is assumed to be used only for developers.
@@ -295,6 +296,8 @@ git config user.name "yourname"
 git config user.email "youremail@somemail.com"
 ```
 
+More information can be found at this GitHub documentation page called [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
 ## Add Changes
 
 Move to a top-level directory, under which your changes exist i.e. `cd ~/bartholomew`.
@@ -307,11 +310,13 @@ git add .
 
 ## Commit Changes
 
-Type the following commit command and ensure to sign off (`--signoff`) and also leave a short message (`-m`):
+Type the following commit command to ensure that you sign off (`--signoff`), sign the data (`-S`) - recommended, and also leave a short message (`-m`):
 
 ```bash
-git commit --signoff -m "Updating documentation about testing process"
+git commit -S --signoff -m "Updating documentation about testing process"
 ```
+
+> Note: the `--signoff` option will only add a Signed-off-by trailer by the committer at the end of the commit log message. In addition to this, it is recommended that you use the `-S` option which will GPG-sign your commits. For more information about using GPG in GitHub see [this GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
 
 ## Push Changes
 At this stage, it is a good idea to just quickly check what GitHub thinks the `origin` is. For example, if we type `git remote -v` we can see that the origin is our repo; which we a) forked the original repo into and b) which we then cloned to our local disk so that we could edit:

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -30,21 +30,4 @@ websites built with Bartholomew are Spin applications that can run in any
 environment that is capable of running Spin. At Fermyon, we run all of our
 websites using Bartholomew and Spin, on our [Fermyon Platform, running on Nomad](https://www.fermyon.com/blog/spin-nomad).
 
-Getting started with your new WebAssembly-powered website is as simple as:
-
-```bash
-# create a new site based on a template repository
-$ bart new site --git https://github.com/fermyon/bartholomew-site-template website
-# run the website using Spin
-$ spin up --file website/spin.toml
-Serving HTTP on address http://127.0.0.1:3000
-Available Routes:
-  bartholomew: http://127.0.0.1:3000 (wildcard)
-  fileserver: http://127.0.0.1:3000/static (wildcard)
-```
-
-Now you can access your new website! Add your Markdown documents in the `content/`
-directory, and Bartholomew will dynamically render the website pages for you on
-each new request.
-
 In the next page, we will [take Bartholomew for a spin](./quickstart.md).

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -4,25 +4,60 @@ date = "2022-05-08T14:05:02.118466Z"
 [extra]
 url = "https://github.com/fermyon/bartholomew/blob/main/docs/content/quickstart.md"
 ---
+This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew site template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](https://bartholomew.fermyon.dev/contributing) which dives a lot deeper than this quickstart example.
 
-This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew website template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](https://bartholomew.fermyon.dev/contributing) which dives a lot deeper than this quickstart example.
-
-## Getting the `bart` and `spin` Binaries
-
-First, you need the `bart` and `spin` binaries configured in your path.
-
-### Spin
+## Getting the `spin` Binary
 
 For Spin, follow [the Spin quickstart guide](https://spin.fermyon.dev/quickstart) which details how to either:
 - download the latest Spin binary release,
-- clone and install Spin using cargo, or
+- clone and build Spin using cargo, or
 - clone and build Spin from source.
+
+## Templates
+
+This quickstart method uses a Bartholomew site template. So while we do require `spin` (as per the details above) everything else we need (to launch our Bartholomew CMS website) is packaged up in the Bartholomew site template. Including the `bartholomew.wasm` and the `spin_static_fs.wasm` files which take care of Bartholomew's business logic and [Spin's file server](https://github.com/fermyon/spin-fileserver) needs, respectively. We will start working with the template in the next section.
+
+## Use the Bartholomew Site Template
+
+We can now generate a new repository with the same directory and file structure as the aforementioned Bartholomew site template. Simply visit [the template's location](https://github.com/fermyon/bartholomew-site-template) on [GitHub](https://github.com/fermyon/bartholomew-site-template). Then click on the green `Use this template` button and follow the prompts. This will create a new repository in your GitHub account.
+
+Here are some additional details about [creating a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) if you are interested.
+
+![Use template](../static/image/docs/use-template.png)
+
+## Fetch Your Site
+
+Clone the repository which you created in the previous step: 
+
+```bash
+$ git clone <your-github-account> <your-repo-name>
+```
+
+Navigate into your newly cloned repository:
+
+```bash
+$ cd <your-repo-name>
+```
+
+## Spin Up Your Site
+
+Issue the following `spin up` command to launch your site on localhost:
+
+```bash
+$ spin up --follow-all
+```
+
+When you navigate to `http://localhost:3000`, you should see the website running.
+
+## Creating Your Content
+
+Creating content is made easy with the Bartholomew Command Line Interface (CLI) tool. The Bartholomew CLI can create new blog posts in a single command and also validate the content (Markdown files) that you write. Let's go ahead and install the Bartholomew CLI.
 
 ### Bartholomew CLI
 
 For the `bart` CLI, there are two options:
 - download the latest `bart` binary [release](https://github.com/fermyon/bartholomew/releases/), or
-- clone and build `bart` from source, using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
+- clone and build `bart` from source (requires Rust), using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
 
 ```bash
 $ git clone https://github.com/fermyon/bartholomew.git
@@ -30,32 +65,11 @@ $ cd bartholomew
 $ make bart
 ```
 
-## Templates
-
-This quickstart method uses a Bartholomew website template. So while we do require `spin` and `bart` CLI (as per the details above) everything else we need (to launch our Bartholomew CMS website) is packaged up in the Bartholomew website template. Including the `bartholomew.wasm` and the `spin_static_fs.wasm` files which take care of Bartholomew's business logic and [Spin's file server](https://github.com/fermyon/spin-fileserver) needs, respectively. We will start working with the template in the next section.
-
-## Create Your First Website
-
-We can now generate a new repository with the same directory and file structure as the template. Simply visit [the template's location](https://github.com/fermyon/bartholomew-site-template) on [GitHub](https://github.com/fermyon/bartholomew-site-template). Then click on the green `Use this template` button and follow the prompts. Here are some additional details about [creating a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) if you are interested.
-
-![Use template](../static/image/docs/use-template.png)
-
-## Customize Your Website
-
-You can clone and customize your own new codebase and then run the website locally, to suit your needs:
-
-```bash
-$ cd <your-repo-name>
-$ spin up --follow-all
-```
-
-When you navigate to `http://localhost:3000`, you should see the website running.
-
 ## Create Your First Blog Post
 
 You are now ready to start adding content to your new website. You will recall that we installed the `bart` CLI in a previous step. We can use this CLI to create a new blog post page.
 
-Note how we:
+Note below how we:
 - set the location where the post will be created i.e. `content/blog`,
 - set the name of the blog file `protons.md`, and
 - specify the `author`, `template` style and `title`.
@@ -67,11 +81,13 @@ $ mkdir content/blog
 $ bart new post content/blog protons.md --author "Enrico Fermi" --template "blog" --title "On the Recombination of Neutrons and Protons"
 ```
 
-The output from the above command, will look similar to the following:
+The output from the above command will look similar to the following:
 
 ```bash
 Wrote new post in file content/blog/protons.md
 ```
+
+## Validate Your Content
 
 If you would like to check the validity of your content, you can use the following `bart check` command. Notice how we specify the location of the content we want to check. In this case, we are checking all of the Markdown files in the blog directory:
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -22,12 +22,12 @@ For Spin, follow [the Spin quickstart guide](https://spin.fermyon.dev/quickstart
 
 For the `bart` CLI, there are two options:
 - download the latest `bart` binary [release](https://github.com/fermyon/bartholomew/releases/), or
-- clone and install `bart` from source, using the following commands:
+- clone and build `bart` from source, using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
 
 ```bash
 $ git clone https://github.com/fermyon/bartholomew.git
 $ cd bartholomew
-$ make bartholomew
+$ make bart
 ```
 
 ## Templates
@@ -53,7 +53,7 @@ When you navigate to `http://localhost:3000`, you should see the website running
 
 ## Create Your First Blog Post
 
-You are now ready to start adding content to your new website. You will recall that we installed the `bart` CLI in a previous step. We can use this CLI to create a new blog post page. 
+You are now ready to start adding content to your new website. You will recall that we installed the `bart` CLI in a previous step. We can use this CLI to create a new blog post page.
 
 Note how we:
 - set the location where the post will be created i.e. `content/blog`,


### PR DESCRIPTION
- fixes #113 

Note: for tweet embedding to work, we also need to add `allowed_http_hosts = ["https://publish.twitter.com"]` to `docs/spin.toml`

e.g.

```
[[component]]
source = "modules/bartholomew.wasm"
id = "bartholomew"
files = [ "content/**/*" , "shortcodes/*" , "templates/*", "scripts/*", "config/*"]
allowed_http_hosts = ["https://publish.twitter.com"]
[component.trigger]
route = "/..."

```