### PR TITLE
ci(.github): add event_type to dispatch payload

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -33,4 +33,4 @@ jobs:
           token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
           repository: ${{ secrets.DEST_REPO }}
           event-type: bartholomew-docs-updated
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"event_type": "bartholomew-docs-updated", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Adds extra context (event type) for use by the downstream GitHub workflow that recieves this event.