### PR TITLE
Remove bart new site command and update signing/commit

### DIFF
--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -280,6 +280,7 @@ Make:
 ```bash
 $ PREVIEW_MODE=1 make serve
 ```
+
 ### The Page Cache
 
 Unless the environment variable `-e DISABLE_CACHE=1` is set, the first load of a site will create a cache of page metadata in `config/_cache.json`. This is an optimization to reduce the number of file IO operations Bartholomew needs to make. If you are actively developing content, we suggest setting `DISABLE_CACHE=1`. By default, the `Makefile`'s `make serve` target disables the cache, as `make serve` is assumed to be used only for developers.
@@ -295,6 +296,8 @@ git config user.name "yourname"
 git config user.email "youremail@somemail.com"
 ```
 
+More information can be found at this GitHub documentation page called [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+
 ## Add Changes
 
 Move to a top-level directory, under which your changes exist i.e. `cd ~/bartholomew`.
@@ -307,11 +310,13 @@ git add .
 
 ## Commit Changes
 
-Type the following commit command and ensure to sign off (`--signoff`) and also leave a short message (`-m`):
+Type the following commit command to ensure that you sign off (`--signoff`), sign the data (`-S`) - recommended, and also leave a short message (`-m`):
 
 ```bash
-git commit --signoff -m "Updating documentation about testing process"
+git commit -S --signoff -m "Updating documentation about testing process"
 ```
+
+> Note: the `--signoff` option will only add a Signed-off-by trailer by the committer at the end of the commit log message. In addition to this, it is recommended that you use the `-S` option which will GPG-sign your commits. For more information about using GPG in GitHub see [this GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account).
 
 ## Push Changes
 At this stage, it is a good idea to just quickly check what GitHub thinks the `origin` is. For example, if we type `git remote -v` we can see that the origin is our repo; which we a) forked the original repo into and b) which we then cloned to our local disk so that we could edit:

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -30,21 +30,4 @@ websites built with Bartholomew are Spin applications that can run in any
 environment that is capable of running Spin. At Fermyon, we run all of our
 websites using Bartholomew and Spin, on our [Fermyon Platform, running on Nomad](https://www.fermyon.com/blog/spin-nomad).
 
-Getting started with your new WebAssembly-powered website is as simple as:
-
-```bash
-# create a new site based on a template repository
-$ bart new site --git https://github.com/fermyon/bartholomew-site-template website
-# run the website using Spin
-$ spin up --file website/spin.toml
-Serving HTTP on address http://127.0.0.1:3000
-Available Routes:
-  bartholomew: http://127.0.0.1:3000 (wildcard)
-  fileserver: http://127.0.0.1:3000/static (wildcard)
-```
-
-Now you can access your new website! Add your Markdown documents in the `content/`
-directory, and Bartholomew will dynamically render the website pages for you on
-each new request.
-
 In the next page, we will [take Bartholomew for a spin](./quickstart.md).

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -4,25 +4,60 @@ date = "2022-05-08T14:05:02.118466Z"
 [extra]
 url = "https://github.com/fermyon/bartholomew/blob/main/docs/content/quickstart.md"
 ---
+This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew site template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](https://bartholomew.fermyon.dev/contributing) which dives a lot deeper than this quickstart example.
 
-This is a quickstart example of using Spin to deploy a Bartholomew CMS instance, locally on your machine. In this quickstart session, we use a Bartholomew website template which contains some pre-built parts (for your convenience). If you would like to build all of the parts separately from source (Spin, Bartholomew, File Server), please see the [contributing section](https://bartholomew.fermyon.dev/contributing) which dives a lot deeper than this quickstart example.
-
-## Getting the `bart` and `spin` Binaries
-
-First, you need the `bart` and `spin` binaries configured in your path.
-
-### Spin
+## Getting the `spin` Binary
 
 For Spin, follow [the Spin quickstart guide](https://spin.fermyon.dev/quickstart) which details how to either:
 - download the latest Spin binary release,
-- clone and install Spin using cargo, or
+- clone and build Spin using cargo, or
 - clone and build Spin from source.
+
+## Templates
+
+This quickstart method uses a Bartholomew site template. So while we do require `spin` (as per the details above) everything else we need (to launch our Bartholomew CMS website) is packaged up in the Bartholomew site template. Including the `bartholomew.wasm` and the `spin_static_fs.wasm` files which take care of Bartholomew's business logic and [Spin's file server](https://github.com/fermyon/spin-fileserver) needs, respectively. We will start working with the template in the next section.
+
+## Use the Bartholomew Site Template
+
+We can now generate a new repository with the same directory and file structure as the aforementioned Bartholomew site template. Simply visit [the template's location](https://github.com/fermyon/bartholomew-site-template) on [GitHub](https://github.com/fermyon/bartholomew-site-template). Then click on the green `Use this template` button and follow the prompts. This will create a new repository in your GitHub account.
+
+Here are some additional details about [creating a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) if you are interested.
+
+![Use template](../static/image/docs/use-template.png)
+
+## Fetch Your Site
+
+Clone the repository which you created in the previous step: 
+
+```bash
+$ git clone <your-github-account> <your-repo-name>
+```
+
+Navigate into your newly cloned repository:
+
+```bash
+$ cd <your-repo-name>
+```
+
+## Spin Up Your Site
+
+Issue the following `spin up` command to launch your site on localhost:
+
+```bash
+$ spin up --follow-all
+```
+
+When you navigate to `http://localhost:3000`, you should see the website running.
+
+## Creating Your Content
+
+Creating content is made easy with the Bartholomew Command Line Interface (CLI) tool. The Bartholomew CLI can create new blog posts in a single command and also validate the content (Markdown files) that you write. Let's go ahead and install the Bartholomew CLI.
 
 ### Bartholomew CLI
 
 For the `bart` CLI, there are two options:
 - download the latest `bart` binary [release](https://github.com/fermyon/bartholomew/releases/), or
-- clone and build `bart` from source, using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
+- clone and build `bart` from source (requires Rust), using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
 
 ```bash
 $ git clone https://github.com/fermyon/bartholomew.git
@@ -30,32 +65,11 @@ $ cd bartholomew
 $ make bart
 ```
 
-## Templates
-
-This quickstart method uses a Bartholomew website template. So while we do require `spin` and `bart` CLI (as per the details above) everything else we need (to launch our Bartholomew CMS website) is packaged up in the Bartholomew website template. Including the `bartholomew.wasm` and the `spin_static_fs.wasm` files which take care of Bartholomew's business logic and [Spin's file server](https://github.com/fermyon/spin-fileserver) needs, respectively. We will start working with the template in the next section.
-
-## Create Your First Website
-
-We can now generate a new repository with the same directory and file structure as the template. Simply visit [the template's location](https://github.com/fermyon/bartholomew-site-template) on [GitHub](https://github.com/fermyon/bartholomew-site-template). Then click on the green `Use this template` button and follow the prompts. Here are some additional details about [creating a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) if you are interested.
-
-![Use template](../static/image/docs/use-template.png)
-
-## Customize Your Website
-
-You can clone and customize your own new codebase and then run the website locally, to suit your needs:
-
-```bash
-$ cd <your-repo-name>
-$ spin up --follow-all
-```
-
-When you navigate to `http://localhost:3000`, you should see the website running.
-
 ## Create Your First Blog Post
 
 You are now ready to start adding content to your new website. You will recall that we installed the `bart` CLI in a previous step. We can use this CLI to create a new blog post page.
 
-Note how we:
+Note below how we:
 - set the location where the post will be created i.e. `content/blog`,
 - set the name of the blog file `protons.md`, and
 - specify the `author`, `template` style and `title`.
@@ -67,11 +81,13 @@ $ mkdir content/blog
 $ bart new post content/blog protons.md --author "Enrico Fermi" --template "blog" --title "On the Recombination of Neutrons and Protons"
 ```
 
-The output from the above command, will look similar to the following:
+The output from the above command will look similar to the following:
 
 ```bash
 Wrote new post in file content/blog/protons.md
 ```
+
+## Validate Your Content
 
 If you would like to check the validity of your content, you can use the following `bart check` command. Notice how we specify the location of the content we want to check. In this case, we are checking all of the Markdown files in the blog directory:
 


### PR DESCRIPTION
Signed-off-by: tpmccallum <tim.mccallum@fermyon.com>

This removes bart new site command (intro page), moves the bart CLI installation down to where it is needed in the workflow (quickstart page) and also adds a couple of links about signing commits and using GPG (contributing page)