### PR TITLE
Seperate server functionality into server feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 flate2 = "1.0.23"
 handlebars = { version = "4.2.2", features = ["dir_source", "script_helper"] }
-handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "f2d42142121d4f04b35ce00fdd26ba48b0993fe0" }
+handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "f2d42142121d4f04b35ce00fdd26ba48b0993fe0", optional = true }
 http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
@@ -28,5 +28,6 @@ members = ["bart"]
 
 
 [features]
-default = ["spin"]
+default = ["server"]
 spin = ["dep:spin-sdk"]
+server = ["spin",  "dep:handlebars_sprig"]

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,18 +1,19 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+#[cfg(feature = "server")]
+use {
+    handlebars::Handlebars, handlebars_sprig, http::HeaderMap, std::collections::BTreeMap,
+    std::path::PathBuf,
+};
 
 use super::content::{Content, Head};
-use handlebars::Handlebars;
-use http::HeaderMap;
 use serde::{Deserialize, Serialize};
-
-use handlebars_sprig;
 
 /// The name of the default template.
 /// This will be resolved to $TEMPLATE_DIR/$DEFAULT_TEMPLATE.hbs
+#[cfg(feature = "server")]
 const DEFAULT_TEMPLATE: &str = "main";
 
 /// Describe the site itself
+#[cfg(feature = "server")]
 #[derive(Serialize, Deserialize)]
 pub struct SiteInfo {
     pub title: String,
@@ -25,6 +26,7 @@ pub struct SiteInfo {
 }
 
 /// Context for a template render.
+#[cfg(feature = "server")]
 #[derive(Serialize)]
 pub struct TemplateContext {
     request: BTreeMap<String, String>,
@@ -46,6 +48,7 @@ pub struct TemplateContext {
 // pub struct RequestValues {}
 
 /// Information about the site, including site info and all of the pages.
+#[cfg(feature = "server")]
 #[derive(Serialize)]
 pub struct SiteValues {
     info: SiteInfo,
@@ -72,6 +75,7 @@ impl From<Content> for PageValues {
 }
 
 /// Renderer can execute a handlebars template and render the results into HTML.
+#[cfg(feature = "server")]
 pub struct Renderer<'a> {
     pub template_dir: PathBuf,
     pub theme_dir: Option<PathBuf>,
@@ -82,6 +86,7 @@ pub struct Renderer<'a> {
     handlebars: handlebars::Handlebars<'a>,
 }
 
+#[cfg(feature = "server")]
 impl<'a> Renderer<'a> {
     /// Create a new renderer with the necessary directories attached.
     pub fn new(
@@ -108,6 +113,7 @@ impl<'a> Renderer<'a> {
 
     /// Load the template directory.
     pub fn load_template_dir(&mut self) -> Result<(), anyhow::Error> {
+        #[cfg(feature = "server")]
         self.register_helpers();
 
         // If there is a theme, load the templates provided by it first
@@ -216,6 +222,7 @@ impl<'a> Renderer<'a> {
     }
 
     /// Add all of the helper functions to this renderer.
+    #[cfg(feature = "server")]
     fn register_helpers(&mut self) {
         handlebars_sprig::addhelpers(&mut self.handlebars)
     }


### PR DESCRIPTION
Split functionality into server feature as per #129. The actual issue arose due to `handlebars-sprig` now having a dependency on `spin-sdk` to enable the tweet embeds functionality. This has now been fixed. 

Tested compiling on both windows 10 VM as well as cross-compiling using the `x86_64-pc-windows-gnu` and `x86_64-pc-windows-msvc` target.

Signed-off-by: Karthik Ganeshram <karthik.ganeshram@fermyon.com>