### PR TITLE
add ability to specify shortocodes directory from bart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 
 .PHONY: check-content
 check-content:
-	cd docs && ../target/release/bart check content/**
+	cd docs && ../target/release/bart check content/** --shortcodes ./shortcodes
 
 .PHONY: serve
 serve: build

--- a/bart/src/commands/check.rs
+++ b/bart/src/commands/check.rs
@@ -10,6 +10,9 @@ pub struct CheckCommand {
     /// The path to check.
     #[structopt()]
     pub paths: Vec<PathBuf>,
+    /// The path to directory containing shortcodes
+    #[structopt(long = "shortcodes")]
+    pub shortcodes_dir: Option<PathBuf>,
 }
 
 impl CheckCommand {
@@ -22,7 +25,7 @@ impl CheckCommand {
             if file_path.is_dir() {
                 continue;
             }
-            match check_file(&file_path).await {
+            match check_file(&file_path, &self.shortcodes_dir).await {
                 Ok(()) => println!(
                     "✅ {}",
                     &file_path.to_str().unwrap_or("").color(Color::Green)
@@ -46,7 +49,7 @@ impl CheckCommand {
     }
 }
 
-async fn check_file(p: &Path) -> Result<()> {
+async fn check_file(p: &Path, shortcodes_dir: &Option<PathBuf>) -> Result<()> {
     let raw_data = std::fs::read_to_string(p)
         .map_err(|e| anyhow::anyhow!("Could not read file {:?} as a string: {}", &p, e))?;
     let mut content: Content = raw_data
@@ -54,7 +57,7 @@ async fn check_file(p: &Path) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Could not parse file {:?}: {}", &p, e))?;
 
     // This will catch (only) panic cases.
-    let _html = content.render_markdown();
+    let _html = content.render_markdown(shortcodes_dir);
 
     // Things we could do from here:
     // - Check whether requested template is known

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -101,6 +101,14 @@ If your syntax in the `.md` file is **correct**, you will receive an output simi
 ✅ content/blog/protons.md
 ```
 
+### Validating content with shortcodes
+
+If some of your documents uses shortcodes, then directory from which the shortcodes must be loaded needs to be specified using the `--shortcodes` flag.
+
+```bash
+bart check content/blog/* --shortcode ./shortcodes
+```
+
 ## Viewing Your Changes
 
 Running the `spin up` command from above (again) will render the post content at `http://localhost:3000/blog/protons`

--- a/src/template.rs
+++ b/src/template.rs
@@ -67,7 +67,7 @@ pub struct PageValues {
 impl From<Content> for PageValues {
     fn from(mut c: Content) -> Self {
         PageValues {
-            body: c.render_markdown(),
+            body: c.render_markdown(&None),
             head: c.head,
             published: c.published,
         }


### PR DESCRIPTION
Fixes a minor bug where `bart check` would pass but complain about undefined helpers when shortcodes are used by adding the ability to specify the shortcodes directory using an optional `shortcodes` flag.

Signed-off-by: Karthik Ganeshram <karthik.ganeshram@fermyon.com>