### PR TITLE
fix: handle cache write error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "handlebars_sprig"
 version = "0.4.0"
-source = "git+https://github.com/rajatjindal/handlebars-sprig?rev=88d05d6c58dfcc1f2c99d7dddeb76f98845d20bb#88d05d6c58dfcc1f2c99d7dddeb76f98845d20bb"
+source = "git+https://github.com/rajatjindal/handlebars-sprig?rev=f2d42142121d4f04b35ce00fdd26ba48b0993fe0#f2d42142121d4f04b35ce00fdd26ba48b0993fe0"
 dependencies = [
  "chrono",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 flate2 = "1.0.23"
 handlebars = { version = "4.2.2", features = ["dir_source", "script_helper"] }
-handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "88d05d6c58dfcc1f2c99d7dddeb76f98845d20bb", optional = true }
+handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "f2d42142121d4f04b35ce00fdd26ba48b0993fe0", optional = true }
 http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/content.rs
+++ b/src/content.rs
@@ -130,18 +130,25 @@ pub fn all_pages(
             // Serialize the files back out to disk for subsequent requests.
             let cache_data = serde_json::to_string(&index_cache.contents)?;
 
-            let f = File::create(CACHE_FILE)?;
-            let mut f = BufWriter::new(f);
-            println!("Writing string  is {}", cache_expiry_time);
-            println!(
-                "Writing Expiry Time is {:#?}",
-                DateTime::parse_from_rfc3339(&cache_expiry_time)
-            );
-            // Cache_contents is stored in a file in the following manner
-            // Cache expiry timer on the 1st line
-            // The rest of the file contains the cache contents
-            writeln!(f, "{}", cache_expiry_time)?;
-            write!(f, "{}", cache_data)?;
+            let cache_file = File::create(CACHE_FILE);
+            match cache_file {
+                Ok(f) => {
+                    let mut f = BufWriter::new(f);
+                    println!("Writing string  is {}", cache_expiry_time);
+                    println!(
+                        "Writing Expiry Time is {:#?}",
+                        DateTime::parse_from_rfc3339(&cache_expiry_time)
+                    );
+                    // Cache_contents is stored in a file in the following manner
+                    // Cache expiry timer on the 1st line
+                    // The rest of the file contains the cache contents
+                    writeln!(f, "{}", cache_expiry_time)?;
+                    write!(f, "{}", cache_data)?;
+                }
+                _ => {
+                    eprintln!("Cannot create Cache file");
+                }
+            }
             Ok(index_cache.contents)
         }
     }


### PR DESCRIPTION
Downgraded `handlebars-sprig` as the latest commit on `handlebars-sprig` contains a template function name `title` which causes errors when using `page.title` in the template.

I will upgrade `handlebar-sprig` once the name collision has been fixed.

Signed-off-by: Karthik Ganeshram <karthik.ganeshram@fermyon.com>