### PR TITLE
change bart install path

### DIFF
--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -57,7 +57,7 @@ Creating content is made easy with the Bartholomew Command Line Interface (CLI) 
 
 For the `bart` CLI, there are two options:
 - download the latest `bart` binary [release](https://github.com/fermyon/bartholomew/releases/), or
-- clone and build `bart` from source (requires Rust), using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/bin/` to be run when built this way.):
+- clone and build `bart` from source (requires Rust), using the following commands (NOTE: `target/release/bart` will need to be installed to a user executable directory such as `/usr/local/bin/` to be run when built this way.):
 
 ```bash
 $ git clone https://github.com/fermyon/bartholomew.git


### PR DESCRIPTION
The recommended location for the spin binary is /usr/local/bin. it seems like bart should be installed in the same location. I think /usr/bin is reserved for system files.

Signed-off-by: Luke Berndt <lukekb@gmail.com>