### PR TITLE
use custom rhai engine for handlebars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,12 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
+ "cfg-if",
+ "const-random",
  "getrandom",
  "once_cell",
  "version_check",
@@ -116,6 +118,7 @@ dependencies = [
  "http",
  "pulldown-cmark 0.9.1",
  "regex",
+ "rhai",
  "serde",
  "serde_json",
  "spin-sdk",
@@ -231,6 +234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bca1619ff57dd7a56b58a8e25ef4199f123e78e503fe1653410350a1b98ae65"
 
 [[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +263,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "digest"
@@ -293,13 +324,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -512,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -651,6 +682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,9 +800,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rhai"
-version = "1.6.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef3d57e55ca044c53ced279d2d3ee9df229b247556b005a23713d5206a2ecfc"
+checksum = "4ff176e72a35d975ea0759b1bed69e30ad5cf47580b2e5d00449e8623b5a37dc"
 dependencies = [
  "ahash",
  "bitflags",
@@ -779,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa0ff1c9dc19c9f8bba510a2a75d3f0449f6233570c2672c7e31c692a11a59a"
+checksum = "db74e3fdd29d969a0ec1f8e79171a6f0f71d0429293656901db382d248c4c021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -875,6 +912,9 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smartstring"
@@ -883,6 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]
@@ -1000,6 +1041,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ handlebars = { version = "4.2.2", features = ["dir_source", "script_helper"] }
 handlebars_sprig = { git = "https://github.com/rajatjindal/handlebars-sprig", rev = "f2d42142121d4f04b35ce00fdd26ba48b0993fe0", optional = true }
 http = "0.2.6"
 pulldown-cmark = { version = "0.9.1", default-features = false }
+rhai = "1.12.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 spin-sdk = { git = "https://github.com/fermyon/spin", rev = "139c40967a75dbdd5d4da2e626d24e68f54c0a5a", optional = true }
@@ -31,4 +32,4 @@ members = ["bart"]
 [features]
 default = ["server"]
 spin = ["dep:spin-sdk"]
-server = ["spin",  "dep:handlebars_sprig"]
+server = ["spin", "dep:handlebars_sprig"]

--- a/src/content.rs
+++ b/src/content.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use chrono::{DateTime, Utc};
 use pulldown_cmark as markdown;
 
+use crate::rhai_engine::custom_rhai_engine_init;
 use crate::template::PageValues;
 
 use handlebars::Handlebars;
@@ -362,6 +363,11 @@ impl Content {
         let parser = match self.head.enable_shortcodes {
             Some(true) => {
                 let mut handlebars = Handlebars::new();
+                // Initialize the custom rhai enginer with helpers
+                let rhai_engine = custom_rhai_engine_init();
+                // Make handlebars use the custom engine
+                handlebars.set_engine(rhai_engine);
+
                 let _ = &self.load_shortcodes_dir(&mut handlebars, shortcodes_dir);
 
                 // don't escape HTML so that rhai scripts can return html that will

--- a/src/content.rs
+++ b/src/content.rs
@@ -363,7 +363,7 @@ impl Content {
         let parser = match self.head.enable_shortcodes {
             Some(true) => {
                 let mut handlebars = Handlebars::new();
-                // Initialize the custom rhai enginer with helpers
+                // Initialize the custom rhai engine with helpers
                 let rhai_engine = custom_rhai_engine_init();
                 // Make handlebars use the custom engine
                 handlebars.set_engine(rhai_engine);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod content;
+pub mod rhai_engine;
 pub mod template;
 
 #[cfg(feature = "spin")]

--- a/src/rhai_engine.rs
+++ b/src/rhai_engine.rs
@@ -1,0 +1,17 @@
+use chrono::{SecondsFormat, Utc};
+use rhai::Engine;
+
+// Creates a custom instance of the rhai enginer with helper functions
+pub fn custom_rhai_engine_init() -> Engine {
+    let mut rhai_engine = Engine::new();
+
+    rhai_engine.register_fn("current_date", current_date);
+
+    rhai_engine
+}
+
+/* Allows access for current_date in rhai script to allow for filtering
+The specific date format is to allow for comparision inside rhai scripts */
+fn current_date() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}

--- a/src/template.rs
+++ b/src/template.rs
@@ -4,6 +4,8 @@ use {
     std::path::PathBuf,
 };
 
+use crate::rhai_engine::custom_rhai_engine_init;
+
 use super::content::{Content, Head};
 use serde::{Deserialize, Serialize};
 
@@ -109,6 +111,11 @@ impl<'a> Renderer<'a> {
         script_dir: PathBuf,
         content_dir: PathBuf,
     ) -> Self {
+        let mut handlebars = Handlebars::new();
+        // Create custom rhai engine and assign to handlebars
+        let rhai_engine = custom_rhai_engine_init();
+        handlebars.set_engine(rhai_engine);
+
         Renderer {
             template_dir,
             theme_dir,
@@ -116,7 +123,7 @@ impl<'a> Renderer<'a> {
             content_dir,
             show_unpublished: false,
             disable_cache: false,
-            handlebars: Handlebars::new(),
+            handlebars,
         }
     }
     // pub fn load(&mut self, name: &str, file: &str) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
This PR updates `handlebars` to use a customized instance of `rhai::Engine`  which allows for extending the scripting capability for templates and shortcodes by allowing the use of rust functions inside rhai scripts. 

This PR also adds the first helper function `current_date` which allows using the current date inside the context of the script which allows conditionally rendering specific pieces of content based on the date. 

This makes it easier to extend the functionality (e.g) pagination. 