### PR TITLE
alternate approach to dynamic templating

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -66,6 +66,9 @@ pub struct Head {
     /// This provides the path info the file
     /// If empty, the path info is filled in using the request url
     pub path_info: Option<String>,
+    /// This provides the path from which to dynamicaly load content for the body
+    /// If empty, the body of the current file is used.
+    pub body_source: Option<String>,
     /// A map of string/string pairs that are user-customizable.
     pub extra: Option<HashMap<String, String>>,
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -286,6 +286,7 @@ pub fn error_values(title: &str, msg: &str) -> PageValues {
             redirect: None,
             enable_shortcodes: None,
             path_info: None,
+            body_source: None,
         },
         body: msg.to_string(),
         published: true,


### PR DESCRIPTION
This PR replaces the approach in https://github.com/fermyon/bartholomew/pull/162. 

Instead of specifying configuration in `config/site.toml`, this approach relies on creating files with a new optional field in the frontmatter (`body_source`). This approach is cleaner in that there is a file for every document that wants to use dynamic content from another document and does not pollute the configuration file. 

An example of using this would be having two content files `doc-a.md` and `doc-b.md` where only `doc-a` has some content. 

`/content/bartholomew/doc-a.md`

```
title = "This is document A"
template = "template_a"
date = "2022-03-14T00:22:56Z"

---

This is some content contained in document A

```

`/content/bartholomew/doc-b.md`

```
title = "This is document B"
template = "template_b"
date = "2022-03-14T00:22:56Z"
body_source = "/bartholomew/doc-b"

---

```

Now `doc-b` would be rendered using the template `template_b` and content from `doc-a`.


Additionally, it potentially opens up the option to explore  options for remote content sources such as mentioned in https://github.com/fermyon/bartholomew/issues/76

I would like to hear some thoughts on this replacement. 