### PR TITLE
add cache control header option

### DIFF
--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -141,13 +141,22 @@ pub fn render(req: Request) -> Result<Response> {
                         .clone()
                         .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_owned());
 
+                    let cache_control = doc.head.cache_control.clone();
+
                     let data = engine
                         .render_template(doc, config, req.headers().to_owned())
                         .map_err(|e| anyhow!("Rendering {:?}: {}", &content_path, e))?;
 
                     let content_encoding = req.headers().get(http::header::ACCEPT_ENCODING);
 
-                    response::send_result(path_info, data, content_type, content_encoding, None)
+                    response::send_result(
+                        path_info,
+                        data,
+                        content_type,
+                        cache_control,
+                        content_encoding,
+                        None,
+                    )
                 }
             }
         }

--- a/src/content.rs
+++ b/src/content.rs
@@ -50,6 +50,11 @@ pub struct Head {
     ///
     /// This may result in HTTP headers being altered.
     pub content_type: Option<String>,
+    /// Cache Control header override.
+    ///
+    /// The default is to send no cache control headers. This should only be
+    /// used when you are sure that the content is safe to be cached.
+    pub cache_control: Option<String>,
     /// An optional status line
     ///
     /// This should only ever be set if the status code is _not_ 200.

--- a/src/response.rs
+++ b/src/response.rs
@@ -45,11 +45,16 @@ pub fn send_result(
     route: String,
     body: String,
     content_type: String,
+    cache_control: Option<String>,
     content_encoding: Option<&HeaderValue>,
     status: Option<u16>,
 ) -> Result<Response> {
     eprintln!("Responded: {route}");
     let mut bldr = Builder::new().header(http::header::CONTENT_TYPE, content_type);
+
+    if let Some(val) = cache_control {
+        bldr = bldr.header(http::header::CACHE_CONTROL, val);
+    }
     if let Some(status) = status {
         bldr = bldr.status(status);
     }

--- a/src/template.rs
+++ b/src/template.rs
@@ -287,6 +287,7 @@ pub fn error_values(title: &str, msg: &str) -> PageValues {
             enable_shortcodes: None,
             path_info: None,
             body_source: None,
+            cache_control: None,
         },
         body: msg.to_string(),
         published: true,


### PR DESCRIPTION
Adds an optional header field to allow the browser to cache the responses.