### PR TITLE
Build bart binaries better

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,26 +8,153 @@ on:
 jobs:
   assets:
     name: Build and release assets
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+              os: "ubuntu-20.04",
+              arch: "amd64",
+              wasiSDK: "linux",
+              extension: "",
+              buildArgs: "",
+              target: "",
+              targetDir: "target/release",
+              buildWasm: true,
+            }
+          - {
+              os: "ubuntu-20.04",
+              arch: "aarch64",
+              wasiSDK: "linux",
+              extension: "",
+              buildArgs: "--target aarch64-unknown-linux-gnu",
+              target: "aarch64-unknown-linux-gnu",
+              targetDir:  "target/release",
+              buildWasm: false,
+            }
+          - {
+              os: "macos-latest",
+              arch: "amd64",
+              wasiSDK: "macos",
+              extension: "",
+              buildArgs: "",
+              target: "",
+              targetDir: "target/release",
+              buildWasm: false,
+            }
+          - {
+              os: "macos-latest",
+              arch: "aarch64",
+              wasiSDK: "macos",
+              extension: "",
+              buildArgs: "--target aarch64-apple-darwin",
+              target: "aarch64-apple-darwin",
+              targetDir: "target/release",
+              buildWasm: false,
+            }
+          - {
+              os: "windows-latest",
+              arch: "amd64",
+              wasiSDK: "",
+              extension: ".exe",
+              buildArgs: "",
+              target: "",
+              targetDir: "target/release",
+              buildWasm: false,
+            }
     steps:
       - uses: actions/checkout@v2
 
       - name: set the release version (tag)
+        shell: bash
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: lowercase the runner OS name
+        shell: bash
+        run: |
+          OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          echo "RUNNER_OS=$OS" >> $GITHUB_ENV
 
-      - name: Install Dependencies
+      - name: Install Rust Wasm target
         run: rustup target add wasm32-wasi
+      - name: Install Rust CPU target
+        if: matrix.config.target != ''
+        shell: bash
+        run: rustup target add ${{ matrix.config.target }}
 
-      - name: Build WASM
+      - name: setup for cross-compiled linux aarch64 build
+        if: matrix.config.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
+          echo 'rustflags = ["-Ctarget-feature=+fp16"]' >> ${HOME}/.cargo/config.toml
+
+      - name: Build Wasm
+        if: matrix.config.buildWasm
         run: make build
+      - name: Upload Wasm as GitHub artifact
+        if: matrix.config.buildWasm
+        uses: actions/upload-artifact@v3
+        with:
+          name: bart
+          path: target/wasm32-wasi/release/bartholomew.wasm
 
       - name: Build bart
-        run: make bart
+        run: cargo build --release --manifest-path=bart/Cargo.toml ${{ matrix.config.extraArgs }}
+
+      - name: package release assets
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir _dist
+          cp ${{ matrix.config.targetDir }}/bart${{ matrix.config.extension }} _dist/
+          cd _dist
+          tar czf \
+            bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz \
+            bart${{ matrix.config.extension }}
+
+      - name: package release assets
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir _dist
+          cp ${{ matrix.config.targetDir }}/bart${{ matrix.config.extension }} _dist/
+          cd _dist
+          7z a -tzip \
+            bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip \
+            bart${{ matrix.config.extension }}
+
+      - name: upload binary as GitHub artifact
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bart
+          path: _dist/bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+
+      - name: upload binary as GitHub artifact
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bart
+          path: _dist/bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+
+  checksums:
+    name: generate release checksums
+    runs-on: ubuntu-latest
+    needs: assets
+    steps:
+      - name: set the release version (tag)
+        run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: bart
 
       - name: generate checksums
-        run: |
-          sha256sum target/wasm32-wasi/release/bartholomew.wasm > checksums-${{ env.RELEASE_VERSION }}.txt
-          sha256sum target/release/bart >> checksums-${{ env.RELEASE_VERSION }}.txt
+        run: sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: Create release
         uses: softprops/action-gh-release@v1
@@ -35,6 +162,7 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           files: |
-            target/wasm32-wasi/release/bartholomew.wasm
-            target/release/bart
+            bartholomew.wasm
+            *.tar.gz
+            *.zip
             checksums-${{ env.RELEASE_VERSION }}.txt

--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -46,8 +46,8 @@ pub fn render(req: Request) -> Result<Response> {
 
     let base_url = std::env::var(BASE_URL_ENV);
 
-    if let Ok(..) = base_url {
-        config.base_url = Some(base_url.unwrap());
+    if let Ok(url) = base_url {
+        config.base_url = Some(url);
     }
     eprintln!("Base URL: {:?}", &config.base_url);
 


### PR DESCRIPTION
In support of https://github.com/fermyon/homebrew-tap/issues/13

Instead of the plain Linux `bart` binary, this now produces (on a tag push):

![image](https://github.com/fermyon/bartholomew/assets/865538/5c599ad7-04f0-48de-8b4c-6c5da7e4a5db)

It would be easy to amend to also upload the current untarred binary if that is considered more convenient or if compatibility with existing docs / workflows is required.