### PR TITLE
allow optionally prepending route info

### DIFF
--- a/src/bartholomew.rs
+++ b/src/bartholomew.rs
@@ -29,7 +29,7 @@ pub fn render(req: Request) -> Result<Response> {
     };
 
     // Get the request path.
-    let path_info = match req.headers().get("spin-path-info") {
+    let mut path_info = match req.headers().get("spin-path-info") {
         Some(p) => {
             if p == "/" {
                 DEFAULT_INDEX.to_owned()
@@ -50,6 +50,16 @@ pub fn render(req: Request) -> Result<Response> {
         config.base_url = Some(url);
     }
     eprintln!("Base URL: {:?}", &config.base_url);
+    eprintln!("Prepend route info : {:?}", &config.prepend_route_info);
+
+    if config.prepend_route_info {
+        let route_info = match req.headers().get("spin-component-route") {
+            Some(route) => route.to_str().unwrap_or_default(),
+            None => "",
+        };
+        path_info = format!("{route_info}{path_info}");
+        eprintln!("Updated request path: {:?}", path_info);
+    }
 
     // If a theme is specifed, create theme path
     let theme_dir = if config.theme.is_some() {

--- a/src/template.rs
+++ b/src/template.rs
@@ -38,6 +38,8 @@ pub struct SiteInfo {
     pub theme: Option<String>,
     pub index_site_pages: Option<Vec<String>>,
     pub dynamic_templates: Option<Vec<DynamicTemplateConfig>>,
+    #[serde(default)]
+    pub prepend_route_info: bool,
     pub extra: BTreeMap<String, String>,
 }
 


### PR DESCRIPTION
This PR allows us to optionally prepend the route info which allows us to mount Bartholomew at multiple routes and still serve from the same base content path. 

(eg)

assuming Bartholomew is mounted at  `/spin/...` and also at `/spin/v1/...`

setting `prepend_route_info` to `true` will allow us to prepend the path allows us to mount both the modules at the same file mounts and serve content as expected. 
