### PR TITLE
create site.pages with globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
+ "glob",
  "handlebars",
  "handlebars_sprig",
  "http",
@@ -162,6 +163,7 @@ dependencies = [
  "serde_json",
  "spin-sdk",
  "toml",
+ "walkdir",
  "wit-bindgen-rust",
 ]
 
@@ -385,6 +387,12 @@ name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "handlebars"
@@ -1366,9 +1374,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ spin-sdk = { git = "https://github.com/fermyon/spin", rev = "139c40967a75dbdd5d4
 toml = "0.5.9"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba", default-features = false }
 regex = "1"
+walkdir = "2.4.0"
+glob = "0.3.1"
 
 [workspace]
 members = ["bart"]

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,3 +1,5 @@
+use anyhow::bail;
+use glob::glob;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -167,6 +169,70 @@ pub fn all_pages(
     }
 }
 
+pub fn get_pages_by_glob(
+    dir: PathBuf,
+    glob: String,
+    show_unpublished: bool,
+) -> anyhow::Result<BTreeMap<String, PageValues>> {
+    let index_cache: IndexCache = pages_by_glob_load(dir, glob, show_unpublished)?;
+    Ok(index_cache.contents)
+}
+
+pub fn all_pages_load(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<IndexCache> {
+    let files = all_files(dir)?;
+    let mut contents = BTreeMap::new();
+    let mut contains_unpublished: bool = false;
+    let mut earliest_unpublished: Option<DateTime<Utc>> = None;
+    for f in files {
+        // Dotfiles should not be loaded.
+        if f.file_name()
+            .map(|f| f.to_string_lossy().starts_with('.'))
+            .unwrap_or(false)
+        {
+            eprintln!("Skipping dotfile {f:?}");
+            continue;
+        }
+        let raw_data = std::fs::read_to_string(&f)
+            .map_err(|e| anyhow::anyhow!("File is not string data: {:?}: {}", &f, e))?;
+        match raw_data.parse::<Content>() {
+            Ok(content) => {
+                if show_unpublished || content.published {
+                    contents.insert(f.to_string_lossy().to_string(), content.into());
+                } else {
+                    // find earliest unpublished article to save timestamp to refresh cache
+                    let article_date = content.head.date;
+                    match contains_unpublished {
+                        true => {
+                            if match earliest_unpublished {
+                                Some(val) => article_date.map(|d| d <= val).unwrap_or(true),
+                                _ => false,
+                            } {
+                                earliest_unpublished = article_date;
+                            }
+                        }
+                        false => {
+                            if let Some(val) = article_date {
+                                if val > Utc::now() {
+                                    earliest_unpublished = article_date;
+                                    contains_unpublished = true;
+                                }
+                            };
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                // If a parse fails, don't take down the entire site. Just skip this piece of content.
+                eprintln!("File {:?}: {}", &f, e);
+                continue;
+            }
+        }
+    }
+    Ok(IndexCache {
+        contents,
+        cache_expiration: earliest_unpublished,
+    })
+}
 pub struct IndexCache {
     contents: BTreeMap<String, PageValues>,
     cache_expiration: Option<DateTime<Utc>>,
@@ -176,8 +242,22 @@ pub struct IndexCache {
 ///
 /// If show_unpublished is `true`, this will include pages that Bartholomew has determined are
 /// unpublished.
-pub fn all_pages_load(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<IndexCache> {
-    let files = all_files(dir)?;
+pub fn pages_by_glob_load(
+    dir: PathBuf,
+    glob_pattern: String,
+    show_unpublished: bool,
+) -> anyhow::Result<IndexCache> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    let full_pattern = format!("{}{}", dir.to_string_lossy(), glob_pattern);
+    let full_path = PathBuf::from(&full_pattern);
+    for entry in glob(full_path.to_str().unwrap_or_default())? {
+        match entry {
+            Ok(path) => files.push(path),
+            Err(e) => {
+                bail!("Failed to read file glob: {e}")
+            }
+        }
+    }
     let mut contents = BTreeMap::new();
     let mut contains_unpublished: bool = false;
     let mut earliest_unpublished: Option<DateTime<Utc>> = None;

--- a/src/content.rs
+++ b/src/content.rs
@@ -180,8 +180,7 @@ pub fn get_pages_by_glob(
 
 pub fn all_pages_load(dir: PathBuf, show_unpublished: bool) -> anyhow::Result<IndexCache> {
     let files = all_files(dir)?;
-    let index_cache = get_index_cache_from_files(files, show_unpublished)?;
-    Ok(index_cache)
+    get_index_cache_from_files(files, show_unpublished)
 }
 pub struct IndexCache {
     contents: BTreeMap<String, PageValues>,
@@ -210,8 +209,7 @@ pub fn pages_by_glob_load(
             }
         }
     }
-    let index_cache = get_index_cache_from_files(files, show_unpublished)?;
-    Ok(index_cache)
+    get_index_cache_from_files(files, show_unpublished)
 }
 
 /// Fetch a list of paths to every file in the directory

--- a/src/template.rs
+++ b/src/template.rs
@@ -179,8 +179,6 @@ impl<'a> Renderer<'a> {
                 }
             }
         }
-        // self.handlebars
-        //     .register_templates_directory(".hbs", &self.template_dir)?;
         Ok(())
     }
 


### PR DESCRIPTION
Allows to add optional frontmatter to templates to allow for reading only files specified by globs instead of all the files in the content folder. 

```
---
read_pages_glob = "events/*.md"
---
```