### PR TITLE
chore(.github): bump artifact actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,9 @@ jobs:
         run: make build
       - name: Upload Wasm as GitHub artifact
         if: matrix.config.buildWasm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bart
+          name: bart-wasm
           path: target/wasm32-wasi/release/bartholomew.wasm
 
       - name: Build bart
@@ -128,16 +128,16 @@ jobs:
 
       - name: upload binary as GitHub artifact
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bart
+          name: bart-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary as GitHub artifact
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bart
+          name: bart-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/bart-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
 
   checksums:
@@ -149,9 +149,10 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: download release assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: bart
+          pattern: bart-*
+          merge-multiple: true
 
       - name: generate checksums
         run: sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt


### PR DESCRIPTION
- Bumps the artifact actions to v4 per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/