### PR TITLE
fix(.github): pin tailscale to 1.78.1 for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_CI_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_CI_OAUTH_SECRET }}
           tags: tag:ci
+          version: 1.78.1
 
       - name: Deploy
         shell: bash


### PR DESCRIPTION
Explicitly sets the tailscale version to the [most recent](https://github.com/tailscale/tailscale/releases/tag/v1.78.1) as of writing.

Otherwise, the most recent v2 release of the GH action ([alas, not very recent](https://github.com/tailscale/github-action/releases/tag/v2)) defaults to a very old 1.42.0 version of tailscale.
